### PR TITLE
Rework of duplicate check

### DIFF
--- a/opr/grading.go
+++ b/opr/grading.go
@@ -52,11 +52,11 @@ func CalculateGrade(avg [20]float64, opr *OraclePriceRecord) float64 {
 // Given a list of OraclePriceRecord, figure out which 10 should be paid, and in what order
 func GradeBlock(list []*OraclePriceRecord) (tobepaid []*OraclePriceRecord, sortedlist []*OraclePriceRecord) {
 
+	list = RemoveDuplicateMiningIDs(list)
+
 	if len(list) < 10 {
 		return nil, nil
 	}
-
-	list = RemoveDuplicateMiningIDs(list)
 
 	// Make sure we have the difficulty calculated for all items in the list.
 	for _, v := range list {

--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) of parts are held by the various contributors (see the CLA)
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+package opr
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/FactomProject/factom"
+)
+
+// "dupe opr". hijacks OPRChainID to store the full name to use while testing
+// the ID is the first character of the name
+func dopr(name string, difficulty uint64) *OraclePriceRecord {
+	//split := strings.Split("name", "")
+	o := new(OraclePriceRecord)
+	o.FactomDigitalID = []string{string(name[0])}
+	o.Difficulty = difficulty
+	o.OPRChainID = name
+	return o
+}
+
+func dupeCheck(got []*OraclePriceRecord, want []string) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("results are not the same length, got = %d, want = %d", len(got), len(want))
+	}
+
+	for i, o := range got {
+		if o.OPRChainID != want[i] {
+			return fmt.Errorf("wrong entry at position %d. got = %s, want = %s", i, o.OPRChainID, want[i])
+		}
+	}
+
+	return nil
+}
+
+func TestRemoveDuplicateMiningIDs(t *testing.T) {
+	// dopr() uses the FIRST CHARACTER as id, and the full name as identifier
+	// eg "a1" and "a2" are duplicate entries
+	type args []*OraclePriceRecord
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"no input", nil, []string{}},
+		{"empty input", args{}, []string{}},
+		{"one input", args{dopr("a1", 1)}, []string{"a1"}},
+		{"two normal inputs", args{dopr("a1", 1), dopr("b1", 1)}, []string{"a1", "b1"}},
+		{"dupe, equal copy", args{dopr("a1", 1), dopr("a2", 1)}, []string{"a1"}},
+		{"dupe, higher copy", args{dopr("a1", 1), dopr("a2", 2)}, []string{"a2"}},
+		{"dupe, lower copy", args{dopr("a1", 2), dopr("a2", 1)}, []string{"a1"}},
+		{"many dupes", args{dopr("a1", 2), dopr("a2", 1), dopr("a3", 5), dopr("a4", 0)}, []string{"a3"}},
+		{"mixed 1", args{dopr("b1", 50), dopr("a1", 2), dopr("a2", 1)}, []string{"b1", "a1"}},
+		{"middle test, keep last", args{dopr("a1", 1), dopr("b1", 50), dopr("a2", 2)}, []string{"b1", "a2"}},
+		{"middle test, keep first", args{dopr("a1", 2), dopr("b1", 50), dopr("a2", 1)}, []string{"a1", "b1"}},
+		{"two dupes", args{dopr("a1", 2), dopr("b1", 50), dopr("a2", 1), dopr("b2", 100)}, []string{"a1", "b2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveDuplicateMiningIDs(tt.args)
+			if err := dupeCheck(got, tt.want); err != nil {
+				t.Errorf("RemoveDuplicateMiningIDs() = %v", err)
+			}
+		})
+	}
+}
+
+func BenchmarkSprintVsHash(b *testing.B) {
+	words := strings.Split("Lorem ipsum dolor sit amet consectetur adipiscing elit Nullam aliquam lacinia ipsum eu blandit Nullam varius ut libero ut vulputate Maecenas id purus quis ligula molestie eleifend Duis maximus neque vitae tempor blandit Praesent commodo orci quis magna imperdiet pulvinar Morbi eget eleifend lectus Nunc eget ligula eu velit faucibus suscipit in non tellus Maecenas nec dictum neque Sed a diam et nisi tincidunt ullamcorper sit amet sit amet sapien Suspendisse ut sollicitudin justo Phasellus tincidunt mauris a dapibus ultrices elit est tincidunt libero nec dictum dui elit id magna Praesent ac magna commodo molestie neque ac imperdiet ipsum Cras sapien felis iaculis porttitor consectetur vel blandit malesuada metus", " ")
+
+	store := make(map[int][][]string)
+	gen := func(n int) [][]string {
+		if existing, ok := store[n]; ok {
+			return existing
+		}
+		random := make([][]string, n)
+		for i := range random {
+			random[i] = make([]string, 0)
+
+			count := 1 + rand.Intn(4) // between 1 and 5 entries for a typical id
+			for c := 0; c < count; c++ {
+				random[i] = append(random[i], words[rand.Intn(len(words))])
+			}
+		}
+		store[n] = random
+		return random
+	}
+
+	b.Run("Sprint ID", func(b *testing.B) {
+		b.StopTimer()
+		random := gen(b.N)
+		b.StartTimer()
+		for i := 0; i < b.N; i++ {
+			_ = fmt.Sprintf("%d+%s", len(random[i]), strings.Join(random[i], "-"))
+		}
+	})
+	b.Run("Sha256 ID", func(b *testing.B) {
+		b.StopTimer()
+		random := gen(b.N)
+		b.StartTimer()
+		for i := 0; i < b.N; i++ {
+			_ = factom.ChainIDFromStrings(random[i])
+		}
+	})
+}

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -20,7 +20,7 @@ func TestOPR_JSON_Marshal(t *testing.T) {
 	//opr.Nonce = base58.Encode(LX.Hash([]byte("a Nonce")))
 	//opr.ChainID = base58.Encode(LX.Hash([]byte("a chainID")))
 	opr.Dbht = 1901232
-	opr.WinningPreviousOPR = [10]string{
+	opr.WinPreviousOPR = [10]string{
 		base58.Encode(LX.Hash([]byte("winner number 1"))),
 		base58.Encode(LX.Hash([]byte("winner number 2"))),
 		base58.Encode(LX.Hash([]byte("winner number 3"))),


### PR DESCRIPTION
Fixes to the following two issues, as detailed in https://github.com/pegnet/pegnet/issues/51:

> Bug 1: it picks duplicates
> This happens when there are two duplicate IDs and the second one in the list has a higher difficulty. it picks the first one because it's the lowest (the only). it picks the second one because the second one has a higher difficulty than the first.
> 
> the algorithm should be altered so that when it finds a new higher record, it removes the previously added record, or does a double-pass. (ultimately the dupe filter should be moved to its own function)
> 
> Bug 2: it creates fewer than 10 winners
> This happens when there are 10 or more entries in the list but there are enough duplicates that the filtered result contains fewer than 10 entries. this will panic and crash the app

Sidenote: Instead of calculating the actual chain ID for the miners, I'm just using Sprintf to print a unique name. There's a benchmark included in the test file, with these results:
```
BenchmarkSprintVsHash/Sprint_ID-8         	 5000000	       369 ns/op	      74 B/op	       4 allocs/op
BenchmarkSprintVsHash/Sha256_ID-8         	  500000	      2644 ns/op	     506 B/op	      11 allocs/op
```
(test using ids generated from 1-5 words)