### PR TITLE
Lint Housekeeping

### DIFF
--- a/opr/balances.go
+++ b/opr/balances.go
@@ -9,6 +9,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Balances holds the non-zero balances for every address for every token in a
+// two dimensional map:
+// assetname => { RCD-hash => balance }
 var Balances map[string]map[[32]byte]int64
 
 func init() {
@@ -19,6 +22,7 @@ func init() {
 	}
 }
 
+// ConvertAddress takes a human-readable address and extracts the prefix and RCD hash
 func ConvertAddress(address string) (prefix string, adr [32]byte, err error) {
 	prefix, adr2, err := common.ConvertPegAddrToRaw(address)
 	if err != nil {
@@ -28,7 +32,7 @@ func ConvertAddress(address string) (prefix string, adr [32]byte, err error) {
 	return
 }
 
-// AddToBalance()
+// AddToBalance adds the given value to the human-readable address
 // Note that add to balance takes a signed update, so this can be used to add to or
 // subtract from a balance.  An error is returned if the value would drive the balance
 // negative.  Or if the string doesn't represent a valid token
@@ -54,8 +58,8 @@ func AddToBalance(address string, value int64) (err error) {
 	return
 }
 
-// GetBalance()
-// Returns the balance for a PegNet asset.  If the address is invalid, a -1 is returned
+// GetBalance returns the balance for a PegNet asset.
+// If the address is invalid, a -1 is returned
 func GetBalance(address string) (balance int64) {
 	prefix, adr, err := ConvertAddress(address)
 	if err != nil {

--- a/opr/grader.go
+++ b/opr/grader.go
@@ -1,31 +1,35 @@
+package opr
+
 // Copyright (c) of parts are held by the various contributors (see the CLA)
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
-package opr
 
 import (
 	"github.com/pegnet/pegnet/common"
 	"github.com/zpatrick/go-config"
 )
 
-// We have one grader that evaluates the previous block of OPRs and determines who should be paid
-// This also informs the miners what records should be included in their OPR records
+// Grader is responsible for evaluating the previous block of OPRs and
+// determines who should be paid.
+// This also informs the miners which records should be included in their OPR records
 type Grader struct {
 	alerts []chan *OPRs
 }
 
-// Alert from the grading service
+// OPRs is the message sent by the Grader
 type OPRs struct {
 	ToBePaid []*OraclePriceRecord
 	AllOPRs  []*OraclePriceRecord
 }
 
-// Miners sign up to be alerted when the grades from the last block are ready
+// GetAlert registers a new request for alerts.
+// Data will be sent when the grades from the last block are ready
 func (g *Grader) GetAlert() chan *OPRs {
 	alert := make(chan *OPRs, 10)
 	g.alerts = append(g.alerts, alert)
 	return alert
 }
 
+// Run the Grader
 func (g *Grader) Run(config *config.Config, monitor *common.FactomdMonitor) {
 	fdAlert := monitor.GetAlert()
 	for {

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dustin/go-humanize"
-
 	"github.com/FactomProject/factom"
+	"github.com/dustin/go-humanize"
 	"github.com/pegnet/pegnet/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/zpatrick/go-config"

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -1,14 +1,16 @@
+package opr
+
 // Copyright (c) of parts are held by the various contributors (see the CLA)
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
-package opr
 
 import (
 	"encoding/hex"
 	"encoding/json"
-	"github.com/dustin/go-humanize"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/dustin/go-humanize"
 
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/common"
@@ -16,7 +18,7 @@ import (
 	"github.com/zpatrick/go-config"
 )
 
-// Compute the average answer for the price of each token reported
+// Avg computes the average answer for the price of each token reported
 func Avg(list []*OraclePriceRecord) (avg [20]float64) {
 
 	// Sum up all the prices
@@ -38,7 +40,7 @@ func Avg(list []*OraclePriceRecord) (avg [20]float64) {
 	return
 }
 
-// Given the average answers across a set of tokens, grade the opr
+// CalculateGrade takes the averages and grades the individual OPRs
 func CalculateGrade(avg [20]float64, opr *OraclePriceRecord) float64 {
 	tokens := opr.GetTokens()
 	opr.Grade = 0
@@ -49,7 +51,8 @@ func CalculateGrade(avg [20]float64, opr *OraclePriceRecord) float64 {
 	return opr.Grade
 }
 
-// Given a list of OraclePriceRecord, figure out which 10 should be paid, and in what order
+// GradeBlock takes all OPRs in a block and sorts them according to Grade and Difficulty.
+// The top ten entries are considered the winners.
 func GradeBlock(list []*OraclePriceRecord) (tobepaid []*OraclePriceRecord, sortedlist []*OraclePriceRecord) {
 
 	list = RemoveDuplicateMiningIDs(list)
@@ -110,18 +113,21 @@ func RemoveDuplicateMiningIDs(list []*OraclePriceRecord) (nlist []*OraclePriceRe
 	return nlist
 }
 
-type OPRBlock struct {
+// block data at a specific height
+type oprBlock struct {
 	OPRs []*OraclePriceRecord
 	Dbht int64
 }
 
-var OPRBlocks []*OPRBlock
-var EBMutex sync.Mutex
+// OPRBlocks holds all the known OPRs
+var OPRBlocks []*oprBlock
 
-// Get the OPR Records at a given dbht
+var ebMutex sync.Mutex
+
+// GetEntryBlocks creates the OPR Records at a given dbht
 func GetEntryBlocks(config *config.Config) {
-	EBMutex.Lock()
-	defer EBMutex.Unlock()
+	ebMutex.Lock()
+	defer ebMutex.Unlock()
 
 	p, err := config.String("Miner.Protocol")
 	check(err)
@@ -137,7 +143,7 @@ func GetEntryBlocks(config *config.Config) {
 	// Because we go from the head of the chain backwards to collect them, they have to be
 	// collected before I can then validate them forward from the highest valid OPR block
 	// I have found.
-	var oprblocks []*OPRBlock
+	var oprblocks []*oprBlock
 	// For each entryblock in the Oracle Price Records chain
 	// Get all the valid OPRs and put them in  a new OPRBlock structure
 	for eb != nil && (len(OPRBlocks) == 0 ||
@@ -145,7 +151,7 @@ func GetEntryBlocks(config *config.Config) {
 
 		// Go through the Entry Block and collect all the valid OPR records
 		if len(eb.EntryList) > 10 {
-			oprblk := new(OPRBlock)
+			oprblk := new(oprBlock)
 			oprblk.Dbht = eb.Header.DBHeight
 			for _, ebentry := range eb.EntryList {
 				entry, err := factom.GetEntry(ebentry.EntryHash)
@@ -260,9 +266,7 @@ func GetEntryBlocks(config *config.Config) {
 	return
 }
 
-// GetPreviousOPRs()
-// So what they are asking for here is the previous winning blocks. In our list, we have graded and ordered
-// the OPRs, so just go through the list and return the highest dbht less than the one asked for.
+// GetPreviousOPRs returns the OPRs in highest-known block less than dbht.
 // Returns nil if the dbht is the first dbht in the chain.
 func GetPreviousOPRs(dbht int32) []*OraclePriceRecord {
 	for i := len(OPRBlocks) - 1; i >= 0; i-- {

--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -199,7 +199,7 @@ func genTest(name string, entries []gradeEntry, results []string) (gt gradeTest)
 		en := genOPR(e)
 
 		en.Entry = difficulty[diff].Entry
-		en.Difficulty = en.Difficulty
+		en.Difficulty = e.difficulty
 
 		gt.args = append(gt.args, en)
 	}

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -1,18 +1,23 @@
+package opr
+
 // Copyright (c) of parts are held by the various contributors (see the CLA)
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
-package opr
 
 import (
 	"errors"
+
+	"strings"
 
 	"github.com/FactomProject/factom"
 	"github.com/cenkalti/backoff"
 	"github.com/pegnet/pegnet/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/zpatrick/go-config"
-	"strings"
 )
 
+// OneMiner starts a single mining goroutine that listens to the monitor.
+// Starts on minute 1 and writes data at minute 9
+// Terminates after writing data.
 func OneMiner(verbose bool, config *config.Config, monitor *common.FactomdMonitor, grader *Grader, miner int) {
 	alert := monitor.GetAlert()
 	gAlert := grader.GetAlert()

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -5,7 +5,6 @@ package opr
 
 import (
 	"errors"
-
 	"strings"
 
 	"github.com/FactomProject/factom"

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"strings"
 
 	"github.com/FactomProject/btcutil/base58"


### PR DESCRIPTION
In the spirit of https://github.com/pegnet/pegnet/issues/73, I'm submitting a bunch of changes to get lint to stop complaining.

Note that https://github.com/pegnet/pegnet/blob/ac613a753089add39ac7414b5fe4156834133e37/opr/opr.go#L37

Was ineffective, and I have updated it to 
```
	FactomDigitalID    []string   `json:"FactomDigitalID"` // [unicode] Digital Identity of the miner
```
which should have no impact on the current json output, since this was supposed to be a non-transformative pull request.
