### PR TITLE
Monitor Rework

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -4,12 +4,6 @@ package common
 
 var PointMultiple float64 = 100000000
 
-// Alert from the Factomd monitor
-type FDStatus struct {
-	Minute int64
-	Dbht   int32
-}
-
 type NetworkType int
 
 const (

--- a/common/monitor.go
+++ b/common/monitor.go
@@ -41,7 +41,7 @@ type MonitorEvent struct {
 	Dbht   int32
 }
 
-// Listener spawns a new listening channel that will receive updates of height or minute changes
+// NewListener spawns a new listening channel that will receive updates of height or minute changes
 func (f *Monitor) NewListener() <-chan MonitorEvent {
 	f.listenerMutex.Lock()
 	defer f.listenerMutex.Unlock()
@@ -51,7 +51,7 @@ func (f *Monitor) NewListener() <-chan MonitorEvent {
 	return listener
 }
 
-// ErrorListener spawns a new listening channel that will receive errors that have occurred
+// NewErrorListener spawns a new listening channel that will receive errors that have occurred
 func (f *Monitor) NewErrorListener() <-chan error {
 	f.errorMutex.Lock()
 	defer f.errorMutex.Unlock()

--- a/common/monitor.go
+++ b/common/monitor.go
@@ -1,158 +1,97 @@
-// Copyright (c) of parts are held by the various contributors (see the CLA)
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
 package common
 
+// Copyright (c) of parts are held by the various contributors (see the CLA)
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
 import (
-	"github.com/FactomProject/factom"
-	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/FactomProject/factom"
 )
 
-// FactomdMonitor
-// Running multiple Monitors is problematic and should be avoided if possible
+// Timeout is the amount of time the Factomd endpoint can be unreachable
+// before shutting down.
+// This allows restarting the endpoint or short network outages.
+var Timeout = time.Second * 90
+var monitor *FactomdMonitor
+var once sync.Once
+
+// GetMonitor returns the singleton instance of the Factomd Monitor
+func GetMonitor() *FactomdMonitor {
+	once.Do(func() {
+		monitor = new(FactomdMonitor)
+		monitor.listeners = []chan FDStatus{}
+		go monitor.poll()
+	})
+	return monitor
+}
+
+// FactomdMonitor polls a factomd node and sends alerts whenever the block height or minute changes
 type FactomdMonitor struct {
-	root       bool            // True if this is the root FactomMonitor
-	mutex      sync.Mutex      // Protect multiple parties accessing monitor data
-	lastminute int64           // Last minute we got
-	lastblock  int64           // Last block we got
-	polltime   int64           // How frequently do we poll
-	kill       chan int        // Channel to kill polling.
-	response   chan int        // Respond when we have stopped
-	alerts     []chan FDStatus // Channels to send minutes to
-	polls      int64
-	info       *factom.CurrentMinuteInfo
-	status     string
+	lastMinute    int64 // Last minute we got
+	lastBlock     int64 // Last block we got
+	listenerMutex sync.Mutex
+	listeners     []chan FDStatus // Channels to send minutes to
+	polls         int64
+	info          *factom.CurrentMinuteInfo
+	status        string
 }
 
-func (f *FactomdMonitor) GetAlert() chan FDStatus {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-	alert := make(chan FDStatus, 10)
-	f.alerts = append(f.alerts, alert)
-	return alert
+// Listener spawns a new listening channel that will receive updates of height or minute changes
+func (f *FactomdMonitor) Listener() <-chan FDStatus {
+	f.listenerMutex.Lock()
+	defer f.listenerMutex.Unlock()
+
+	listener := make(chan FDStatus, 10)
+	f.listeners = append(f.listeners, listener)
+	return listener
 }
 
-// GetBlockTime
-// Returns the blocktime in seconds.  All blocks are divided into 10 "minute" sections.  But if the blocktime
-// is not 600 seconds, then a minute = the blocktime/10
-func (f *FactomdMonitor) GetBlockTime() int64 {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-	return f.info.DirectoryBlockInSeconds
+// waitForNextHeight polls the node every second until a different height is reached.
+// If the underlying factomd is swapped out this might result in a time rollback
+func (f *FactomdMonitor) waitForNextMinute(limit int) *factom.CurrentMinuteInfo {
+	end := time.Now().Add(Timeout)
+	for {
+		f.polls++
+		info, err := factom.GetCurrentMinute()
+
+		if err != nil {
+			f.status = err.Error()
+		} else if info.DirectoryBlockHeight < f.lastBlock {
+			// restarting?
+		} else if info.DirectoryBlockHeight > f.lastBlock || info.Minute != f.lastMinute {
+			return info
+		}
+
+		if end.Before(time.Now()) {
+			panic("Monitor: unable to retrieve current minute info: " + f.status)
+		}
+		time.Sleep(time.Second)
+	}
 }
 
-// Returns the highest saved block
-func (f *FactomdMonitor) GetHighestSavedDBlock() int64 {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-	return f.info.DirectoryBlockHeight
-}
-
-// poll
-// Go process to poll the Factoid client to provide insight into its operations.
+// poll the factomd node and notify listeners of minute/height changes
 func (f *FactomdMonitor) poll() {
 	for {
-		var err error
-		for {
-			f.mutex.Lock()
+		info := f.waitForNextMinute(90)
+		f.info = info
+		f.lastMinute = info.Minute
+		f.lastBlock = info.DirectoryBlockHeight
 
-			// If we have a kill message, die!
-			select {
-			case <-f.kill:
-				f.response <- 1
-				f.mutex.Unlock()
-				return
-			default:
-			}
-
-			for {
-				var dbht int64
-				if f.info != nil {
-					dbht = f.info.DirectoryBlockHeight
-				}
-				// Do our poll
-				f.info, err = factom.GetCurrentMinute()
-
-				f.mutex.Unlock()
-
-				for i := 0; i < 1000 && err != nil; i++ {
-					time.Sleep(time.Duration(rand.Intn(50)+50) * time.Millisecond)
-					// Do our poll
-					f.mutex.Lock()
-					f.info, err = factom.GetCurrentMinute()
-					f.mutex.Unlock()
-
-					if f.info != nil && err == nil {
-						break
-					}
-				}
-				f.mutex.Lock()
-				if dbht < f.info.DirectoryBlockHeight { // Keep looking if the dbht hasn't progressed forward
-					continue // Mostly this happens when the factomd node is rebooted.
-				}
-				f.info.DirectoryBlockHeight = dbht
-				break
-			}
-
-			// track how often we poll
-			f.polls++
-
-			// If we get an error, then report and break
-			if err != nil {
-				f.status = err.Error()
-				panic("Error with getting minute. " + f.status)
-
-				break
-			}
-			// If we got a different block time, consider that good and break
-			if f.info.Minute != f.lastminute || f.info.DirectoryBlockHeight != f.lastblock {
-				f.lastminute = f.info.Minute
-				f.lastblock = f.info.DirectoryBlockHeight
-				break
-			}
-
-			// Poll once per second until we get a new minute
-			f.mutex.Unlock()
-			time.Sleep(1 * time.Second)
+		fds := FDStatus{
+			Dbht:   int32(f.lastBlock),
+			Minute: f.lastMinute,
 		}
 
 		// send alerts to all interested parties
-		for _, alert := range f.alerts {
-			if cap(alert) > len(alert) {
-				var fds FDStatus
-				fds.Dbht = int32(f.info.DirectoryBlockHeight)
-				fds.Minute = f.info.Minute
-				alert <- fds
+		f.listenerMutex.Lock()
+		for _, alert := range f.listeners {
+			select {
+			case alert <- fds:
+			default:
 			}
 		}
-
-		f.mutex.Unlock()
-		// Poll once per second
-		time.Sleep(time.Duration(time.Second))
+		f.listenerMutex.Unlock()
 	}
-}
-
-func (f *FactomdMonitor) Start() {
-	f.mutex.Lock()
-	if f.kill == nil {
-		f.response = make(chan int, 1)
-		f.alerts = []chan FDStatus{}
-		f.kill = make(chan int, 1)
-		factom.SetFactomdServer("localhost:8088")
-		factom.SetWalletServer("localhost:8089")
-		go f.poll()
-	}
-	f.mutex.Unlock()
-	return
-}
-
-func (f *FactomdMonitor) Stop() {
-	f.mutex.Lock()
-	kill := f.kill
-	response := f.response
-	f.mutex.Unlock()
-
-	kill <- 0
-	<-response
 }

--- a/common/monitor.go
+++ b/common/monitor.go
@@ -14,84 +14,121 @@ import (
 // before shutting down.
 // This allows restarting the endpoint or short network outages.
 var Timeout = time.Second * 90
-var monitor *FactomdMonitor
+var monitor *Monitor
 var once sync.Once
 
 // GetMonitor returns the singleton instance of the Factomd Monitor
-func GetMonitor() *FactomdMonitor {
+func GetMonitor() *Monitor {
 	once.Do(func() {
-		monitor = new(FactomdMonitor)
-		monitor.listeners = []chan FDStatus{}
+		monitor = new(Monitor)
+		monitor.errors = []chan error{}
+		monitor.listeners = []chan MonitorEvent{}
 		go monitor.poll()
 	})
 	return monitor
 }
 
-// FactomdMonitor polls a factomd node and sends alerts whenever the block height or minute changes
-type FactomdMonitor struct {
-	lastMinute    int64 // Last minute we got
-	lastBlock     int64 // Last block we got
+// Monitor polls a factomd node and sends alerts whenever the block height or minute changes
+type Monitor struct {
+	polls int64
+
 	listenerMutex sync.Mutex
-	listeners     []chan FDStatus // Channels to send minutes to
-	polls         int64
-	info          *factom.CurrentMinuteInfo
-	status        string
+	listeners     []chan MonitorEvent // Channels to send minutes to
+	errorMutex    sync.Mutex
+	errors        []chan error
+}
+
+// MonitorEvent is the data sent to all listeners when being notified
+type MonitorEvent struct {
+	Minute int64
+	Dbht   int32
 }
 
 // Listener spawns a new listening channel that will receive updates of height or minute changes
-func (f *FactomdMonitor) Listener() <-chan FDStatus {
+func (f *Monitor) Listener() <-chan MonitorEvent {
 	f.listenerMutex.Lock()
 	defer f.listenerMutex.Unlock()
 
-	listener := make(chan FDStatus, 10)
+	listener := make(chan MonitorEvent, 10)
 	f.listeners = append(f.listeners, listener)
 	return listener
 }
 
-// waitForNextHeight polls the node every second until a different height is reached.
-// If the underlying factomd is swapped out this might result in a time rollback
-func (f *FactomdMonitor) waitForNextMinute(limit int) *factom.CurrentMinuteInfo {
+// ErrorListener spawns a new listening channel that will receive errors that have occurred
+func (f *Monitor) ErrorListener() <-chan error {
+	f.errorMutex.Lock()
+	defer f.errorMutex.Unlock()
+
+	listener := make(chan error, 1)
+	f.errors = append(f.errors, listener)
+	return listener
+}
+
+// waitForNextHeight polls the node every second until a new height is reached.
+func (f *Monitor) waitForNextMinute(current factom.CurrentMinuteInfo) (factom.CurrentMinuteInfo, error) {
 	end := time.Now().Add(Timeout)
 	for {
 		f.polls++
 		info, err := factom.GetCurrentMinute()
 
-		if err != nil {
-			f.status = err.Error()
-		} else if info.DirectoryBlockHeight < f.lastBlock {
-			// restarting?
-		} else if info.DirectoryBlockHeight > f.lastBlock || info.Minute != f.lastMinute {
-			return info
+		if err == nil {
+			if info.DirectoryBlockHeight > current.DirectoryBlockHeight {
+				return *info, nil
+			}
+
+			if info.DirectoryBlockHeight == current.DirectoryBlockHeight && current.Minute != info.Minute {
+				return *info, nil
+			}
+
+			// the API has a lower height than the one we've seen
+			time.Sleep(time.Second)
+			continue
 		}
 
 		if end.Before(time.Now()) {
-			panic("Monitor: unable to retrieve current minute info: " + f.status)
+			return factom.CurrentMinuteInfo{}, err
 		}
-		time.Sleep(time.Second)
+		time.Sleep(time.Millisecond * 100)
+	}
+}
+
+func (f *Monitor) notifyError(err error) {
+	f.errorMutex.Lock()
+	defer f.errorMutex.Unlock()
+	for _, ec := range f.errors {
+		select {
+		case ec <- err:
+		default:
+		}
+	}
+}
+
+func (f *Monitor) notify(info factom.CurrentMinuteInfo) {
+	f.listenerMutex.Lock()
+	defer f.listenerMutex.Unlock()
+
+	fds := MonitorEvent{
+		Dbht:   int32(info.DirectoryBlockHeight),
+		Minute: info.Minute,
+	}
+	for _, l := range f.listeners {
+		select {
+		case l <- fds:
+		default:
+		}
 	}
 }
 
 // poll the factomd node and notify listeners of minute/height changes
-func (f *FactomdMonitor) poll() {
+func (f *Monitor) poll() {
+	var info factom.CurrentMinuteInfo
+	var err error
 	for {
-		info := f.waitForNextMinute(90)
-		f.info = info
-		f.lastMinute = info.Minute
-		f.lastBlock = info.DirectoryBlockHeight
-
-		fds := FDStatus{
-			Dbht:   int32(f.lastBlock),
-			Minute: f.lastMinute,
+		info, err = f.waitForNextMinute(info)
+		if err != nil {
+			f.notifyError(err)
+			continue
 		}
-
-		// send alerts to all interested parties
-		f.listenerMutex.Lock()
-		for _, alert := range f.listeners {
-			select {
-			case alert <- fds:
-			default:
-			}
-		}
-		f.listenerMutex.Unlock()
+		f.notify(info)
 	}
 }

--- a/common/monitor.go
+++ b/common/monitor.go
@@ -27,7 +27,6 @@ func GetMonitor() *Monitor {
 
 // Monitor polls a factomd node and sends alerts whenever the block height or minute changes
 type Monitor struct {
-	polls   int64
 	timeout time.Duration
 
 	listenerMutex sync.Mutex
@@ -43,7 +42,7 @@ type MonitorEvent struct {
 }
 
 // Listener spawns a new listening channel that will receive updates of height or minute changes
-func (f *Monitor) Listener() <-chan MonitorEvent {
+func (f *Monitor) NewListener() <-chan MonitorEvent {
 	f.listenerMutex.Lock()
 	defer f.listenerMutex.Unlock()
 
@@ -53,7 +52,7 @@ func (f *Monitor) Listener() <-chan MonitorEvent {
 }
 
 // ErrorListener spawns a new listening channel that will receive errors that have occurred
-func (f *Monitor) ErrorListener() <-chan error {
+func (f *Monitor) NewErrorListener() <-chan error {
 	f.errorMutex.Lock()
 	defer f.errorMutex.Unlock()
 
@@ -88,13 +87,12 @@ func (f *Monitor) getMinute() (*factom.CurrentMinuteInfo, error) {
 	if fail != nil {
 		return nil, fail
 	}
-	return info, err
+	return info, nil
 }
 
 // waitForNextHeight polls the node every second until a new height is reached.
 func (f *Monitor) waitForNextMinute(current factom.CurrentMinuteInfo) (factom.CurrentMinuteInfo, error) {
 	for {
-		f.polls++
 		info, err := f.getMinute()
 
 		if err != nil {

--- a/opr/grader.go
+++ b/opr/grader.go
@@ -26,8 +26,8 @@ func (g *Grader) GetAlert() chan *OPRs {
 	return alert
 }
 
-func (g *Grader) Run(config *config.Config, monitor *common.FactomdMonitor) {
-	fdAlert := monitor.GetAlert()
+func (g *Grader) Run(config *config.Config, monitor *common.Monitor) {
+	fdAlert := monitor.Listener()
 	for {
 		fds := <-fdAlert
 		if fds.Minute == 1 {

--- a/opr/grader.go
+++ b/opr/grader.go
@@ -27,7 +27,7 @@ func (g *Grader) GetAlert() chan *OPRs {
 }
 
 func (g *Grader) Run(config *config.Config, monitor *common.Monitor) {
-	fdAlert := monitor.Listener()
+	fdAlert := monitor.NewListener()
 	for {
 		fds := <-fdAlert
 		if fds.Minute == 1 {

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -5,16 +5,17 @@ package opr
 import (
 	"errors"
 
+	"strings"
+
 	"github.com/FactomProject/factom"
 	"github.com/cenkalti/backoff"
 	"github.com/pegnet/pegnet/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/zpatrick/go-config"
-	"strings"
 )
 
-func OneMiner(verbose bool, config *config.Config, monitor *common.FactomdMonitor, grader *Grader, miner int) {
-	alert := monitor.GetAlert()
+func OneMiner(verbose bool, config *config.Config, monitor *common.Monitor, grader *Grader, miner int) {
+	alert := monitor.Listener()
 	gAlert := grader.GetAlert()
 
 	mining := false

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OneMiner(verbose bool, config *config.Config, monitor *common.Monitor, grader *Grader, miner int) {
-	alert := monitor.Listener()
+	alert := monitor.NewListener()
 	gAlert := grader.GetAlert()
 
 	mining := false

--- a/pegnetMining/Miner.go
+++ b/pegnetMining/Miner.go
@@ -80,7 +80,7 @@ func main() {
 	monitor.SetTimeout(time.Duration(Timeout) * time.Second)
 
 	go func() {
-		errListener := monitor.ErrorListener()
+		errListener := monitor.NewErrorListener()
 		err := <-errListener
 		panic("Monitor threw error: " + err.Error())
 	}()

--- a/pegnetMining/Miner.go
+++ b/pegnetMining/Miner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/user"
 	"strings"
+	"time"
 
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/common"
@@ -23,6 +24,7 @@ var (
 	FactomdLocation string
 	WalletdLocation string
 	ECAddressString string
+	Timeout         uint
 )
 
 func init() {
@@ -30,6 +32,7 @@ func init() {
 	flag.StringVar(&FactomdLocation, "s", "localhost:8088", "IPAddr:port# of factomd API to use to access blockchain (default localhost:8088)")
 	flag.StringVar(&WalletdLocation, "w", "localhost:8089", "IPAddr:port# of factom-walletd API to use to create transactions (default localhost:8089)")
 	flag.StringVar(&ECAddressString, "ec", "", "EC Address to use in place of the one specified in PegNet config file")
+	flag.UintVar(&Timeout, "timeout", 90, "The time (in seconds) that the miner tolerates the downtime of the factomd API before shutting down")
 }
 
 // Run a set of miners, as a network debugging aid
@@ -74,6 +77,7 @@ func main() {
 	}
 
 	monitor := common.GetMonitor()
+	monitor.SetTimeout(time.Duration(Timeout) * time.Second)
 
 	go func() {
 		errListener := monitor.ErrorListener()

--- a/pegnetMining/Miner.go
+++ b/pegnetMining/Miner.go
@@ -74,6 +74,13 @@ func main() {
 	}
 
 	monitor := common.GetMonitor()
+
+	go func() {
+		errListener := monitor.ErrorListener()
+		err := <-errListener
+		panic("Monitor threw error: " + err.Error())
+	}()
+
 	grader := new(opr.Grader)
 	go grader.Run(Config, monitor)
 

--- a/pegnetMining/Miner.go
+++ b/pegnetMining/Miner.go
@@ -73,8 +73,7 @@ func main() {
 		log.SetLevel(log.FatalLevel)
 	}
 
-	monitor := new(common.FactomdMonitor)
-	monitor.Start()
+	monitor := common.GetMonitor()
 	grader := new(opr.Grader)
 	go grader.Run(Config, monitor)
 


### PR DESCRIPTION
As announced in https://github.com/pegnet/pegnet/issues/65, I've reworked the monitor.

There is now a singleton monitor that you can access via `common.GetMonitor()` which initializes and starts the thing. It is possible to start other monitors if you so choose and they won't interfere with each other, but you will have to do it manually.

The giant, confusing loop has been split up into a couple different function calls that should hopefully clear up the functionality and make it easier to test.

There was a bug in the old code that prevented proper error management: 
https://github.com/pegnet/pegnet/blob/ac613a753089add39ac7414b5fe4156834133e37/common/monitor.go#L79-L91

This loop polled factomd node for ~75 seconds, after which it exited with `f.info = nil`. The code immediately afterward accesses `f.info.DirectoryBlockHeight`, which results in a nil-pointer panic. 

I reworked the error management system so the monitor has a timeout, after which it sends the error to the timeout listener. The monitor will continue to keep going and continue throwing errors every specified timeout. At the moment, there is an error listener in `Miner.go` that panics when an error occurs (since it usually means the node is down). If the Timeout is zero, every error is reported.

I also wasn't sure whether to allow rollbacks of heights, which can happen if the underlying factomd node is swapped out at runtime to a node with a lower height. At the moment, it reports all events that are at equal or higher blockheight and don't allow rollbacks. If the endpoint is restarted, the blockheight is the same and the minute rolls back to 0, which is allowed.

I also renamed a bunch of stuff and removed unnecessary info. If there's a need to ever stop and restart the monitor while the node is running, I can re-add that functionality.