### PR TITLE
Pnt 40 ci allow windows failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ os:
   - osx
   - windows
 
-allow_failures:
-  - os: windows
+matrix:
+  fast_finish: true
+  allow_failures:
+    - os: windows
 
 # GO111MODULE will force Go modules
 # This will be unnecessary when Go 1.13 lands.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ os:
   - osx
   - windows
 
+allow_failures:
+  - os: windows
+
 # GO111MODULE will force Go modules
 # This will be unnecessary when Go 1.13 lands.
 env:


### PR DESCRIPTION
Windows builds are still in early access on Travis CI, recently there was a build that only failed on windows, yet I could get the branch to build on a local windows machine. 

This modification will still build for windows and show up in the report but any failure will not affect the final pass/fail grading. Until they stabilise the feature it's probably the easiest way. There's nothing in the codebase that should be affected by platform anyway.