### PR TITLE
Pnt 46 Remove log duplication

### DIFF
--- a/common/log.go
+++ b/common/log.go
@@ -18,11 +18,6 @@ var DoLogging bool = false
 var start int64
 var LogFile = os.Stdout
 
-func init() {
-	fmt.Println(time.Now().String())
-	start = time.Now().UnixNano()
-}
-
 // Some parameters are really pricey to compute.  So use Do in those cases.
 // common.Do(func() {
 //    common.Logf("sortMessages", "%s", AReallyExpensiveThing())

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -6,6 +6,7 @@ package opr
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -266,8 +267,8 @@ func GetEntryBlocks(config *config.Config) {
 					"place":      place,
 					"fid":        fid,
 					"entry_hash": hex.EncodeToString(win.Entry.Hash()[:8]),
-					"grade":      win.Grade,
-					"difficulty": win.Difficulty,
+					"grade":      fmt.Sprintf("%.4e", win.Grade),
+					"difficulty": fmt.Sprintf("%.10e", float64(win.Difficulty)),
 					"address":    win.CoinbasePNTAddress,
 					"balance":    humanize.Comma(GetBalance(win.CoinbasePNTAddress)),
 				}).Info("New OPR Winner")

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -230,13 +230,15 @@ func GetEntryBlocks(config *config.Config) {
 		oprblocks[i].OPRs = winners
 		OPRBlocks = append(OPRBlocks, oprblocks[i])
 
-		log.WithFields(log.Fields{
-			"height": humanize.Comma(oprblocks[i].Dbht),
-		}).Info("Added new valid block to OPR Chain")
+		if i == 0 {
+			log.WithFields(log.Fields{
+				"height": humanize.Comma(oprblocks[i].Dbht),
+			}).Info("Added new valid block to OPR Chain")
+		}
 
 		// Update the balances for each winner
-		for i, win := range winners {
-			switch i {
+		for place, win := range winners {
+			switch place {
 			// The Big Winner
 			case 0:
 				err := AddToBalance(win.CoinbasePNTAddress, 800)
@@ -259,15 +261,17 @@ func GetEntryBlocks(config *config.Config) {
 			for _, f := range win.FactomDigitalID[1:] {
 				fid = fid + "-" + f
 			}
-			log.WithFields(log.Fields{
-				"place":      i,
-				"fid":        fid,
-				"entry_hash": hex.EncodeToString(win.Entry.Hash()[:8]),
-				"grade":      win.Grade,
-				"difficulty": win.Difficulty,
-				"address":    win.CoinbasePNTAddress,
-				"balance":    humanize.Comma(GetBalance(win.CoinbasePNTAddress)),
-			}).Info("New OPR Winner")
+			if i == 0 {
+				log.WithFields(log.Fields{
+					"place":      place,
+					"fid":        fid,
+					"entry_hash": hex.EncodeToString(win.Entry.Hash()[:8]),
+					"grade":      win.Grade,
+					"difficulty": win.Difficulty,
+					"address":    win.CoinbasePNTAddress,
+					"balance":    humanize.Comma(GetBalance(win.CoinbasePNTAddress)),
+				}).Info("New OPR Winner")
+			}
 		}
 	}
 	return

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -42,8 +42,8 @@ func OneMiner(verbose bool, config *config.Config, monitor *common.Monitor, grad
 				}
 				if verbose {
 					log.WithFields(log.Fields{
-						"did": strings.Join(opr.FactomDigitalID, "-"),
-						"Miners": numMiners,
+						"did": strings.Join(opr.FactomDigitalID[:len(opr.FactomDigitalID)-1], "-"),
+						"miner_count": numMiners,
 					}).Info("New OPR miners")
 
 				}

--- a/opr/oneminer.go
+++ b/opr/oneminer.go
@@ -21,6 +21,7 @@ func OneMiner(verbose bool, config *config.Config, monitor *common.Monitor, grad
 	alert := monitor.NewListener()
 	gAlert := grader.GetAlert()
 
+	numMiners, _ := config.Int("Miner.NumberOfMiners")
 	mining := false
 	var opr *OraclePriceRecord
 	var err error
@@ -39,9 +40,13 @@ func OneMiner(verbose bool, config *config.Config, monitor *common.Monitor, grad
 				if err != nil {
 					log.WithError(err).Fatal("Error creating an OPR.  Likely a config file issue")
 				}
-				log.WithFields(log.Fields{
-					"did": strings.Join(opr.FactomDigitalID, "-"),
-				}).Info("New OPR miner")
+				if verbose {
+					log.WithFields(log.Fields{
+						"did": strings.Join(opr.FactomDigitalID, "-"),
+						"Miners": numMiners,
+					}).Info("New OPR miners")
+
+				}
 				go opr.Mine(verbose)
 			}
 		case 9:


### PR DESCRIPTION
Removes duplication of "New OPR Miner" printed for every new miner, now simply one print with the number of miners included.

On startup every previous OPR winner would log. For anyone stopping and starting this fills up files quickly with an obscene amount of info level logs. This fix only prints the winners from most recent block.

Additionally, the very large and small number fields of difficulty/grading are shortened in scientific notation for readability.

Unused and duplicated common.init() function is also removed.


