### PR TITLE
Move mining into seperate command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ myconfig.ini
 
 # VSCode
 .vscode/*
+
+# Miner
+pegnet

--- a/cmd/args.go
+++ b/cmd/args.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/common"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -170,4 +171,20 @@ func factoidToFactoshi(amt string) (uint64, error) {
 	}
 
 	return total, nil
+}
+
+func ArgParseMining(args []string) int {
+	if len(args) != 0 {
+		num, err := strconv.Atoi(args[0])
+		if err != nil || num == 0 {
+			log.Info("Invalid number of miners, using config default")
+		} else {
+			return num
+		}
+	}
+	configMiners, err := Config.Int("Miner.NumberOfMiners")
+	if err != nil {
+		log.WithError(err).Fatal("Failed to read number of miners from config")
+	}
+	return configMiners
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,17 +5,11 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"os/user"
 	"strings"
-	"time"
 
 	"github.com/FactomProject/factom"
-	"github.com/pegnet/pegnet/api"
-	"github.com/pegnet/pegnet/common"
-	"github.com/pegnet/pegnet/opr"
-	"github.com/pegnet/pegnet/pegnetMining"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/zpatrick/go-config"
@@ -40,7 +34,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&LogLevel, "log", "info", "Change the logging level. Can choose from 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'")
 	rootCmd.PersistentFlags().StringVar(&FactomdLocation, "s", "localhost:8088", "IPAddr:port# of factomd API to use to access blockchain (default localhost:8088)")
 	rootCmd.PersistentFlags().StringVar(&WalletdLocation, "w", "localhost:8089", "IPAddr:port# of factom-walletd API to use to create transactions (default localhost:8089)")
-	rootCmd.PersistentFlags().IntVar(&Miners, "miners", 0, "Change the number of miners being run (default 0)")
 	rootCmd.PersistentFlags().UintVar(&Timeout, "timeout", 90, "The time (in seconds) that the miner tolerates the downtime of the factomd API before shutting down")
 	rootCmd.PersistentFlags().StringVar(&Network, "network", "test", "The pegnet network to target. <Main|Test>")
 
@@ -53,40 +46,8 @@ var rootCmd = &cobra.Command{
 	Use:   "pegnet",
 	Short: "pegnet is the cli tool to run or interact with a PegNet node",
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Do we really want to init the miner by default?
-		//  	 Not like `pegnet -service=miner` or something?
-		_, err := Config.String("Miner.Protocol")
-		if err != nil {
-			log.WithError(err).Fatal("Failed to read miner protocol from config")
-		}
-		configMiners, err := Config.Int("Miner.NumberOfMiners")
-		if err != nil {
-			log.WithError(err).Fatal("Failed to read number of miners from config")
-		}
-
-		// Default to config options if cli flags aren't specified
-		if Miners == 0 {
-			Miners = configMiners
-		}
-
-		monitor := common.GetMonitor()
-		monitor.SetTimeout(time.Duration(Timeout) * time.Second)
-
-		go func() {
-			errListener := monitor.NewErrorListener()
-			err := <-errListener
-			panic("Monitor threw error: " + err.Error())
-		}()
-
-		grader := new(opr.Grader)
-		go grader.Run(Config, monitor)
-
-		http.Handle("/v1", api.RequestHandler{})
-		go http.ListenAndServe(":8099", nil)
-
-		if Miners > 0 {
-			pegnetMining.Mine(Miners, Config, monitor, grader)
-		}
+		cmd.Help()
+		os.Exit(0)
 	},
 }
 

--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -127,6 +127,7 @@ func uniqID() string {
 var difficulty []*OraclePriceRecord
 
 func init() {
+	LX.Init(0x123412341234, 25, 256, 5)
 	// create difficulties that are in order and indexed in an array so I can assign them and compare
 	// them in the tests.
 	for i := 0; i < 100; i++ {

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -67,10 +67,6 @@ var LX lxr.LXRHash
 // OPRChainID is the calculated chain id of the records chain
 var OPRChainID string
 
-func init() {
-	LX.Init(0xfafaececfafaecec, 25, 256, 5)
-}
-
 // Token is a combination of currency code and value
 type Token struct {
 	code  string


### PR DESCRIPTION
Running the pegnet binary without any arguments will now return the help menu.

To activate the miner:  `pegnet mine`

To use a custom number of miners: `pegnet mine 22`

Using zero or not a number will default to the config setting.

Hashtable won't be initialized now unless mining is specified. 

Tests requiring `LX.Hash()` in future will need to initialize it.

References: https://github.com/pegnet/pegnet/issues/92
Closes: https://github.com/pegnet/pegnet/issues/87