### PR TITLE
Added line numbers to the error printouts

### DIFF
--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -66,3 +66,51 @@ func TestOPR_JSON_Marshal(t *testing.T) {
 		t.Error("JSON is different")
 	}
 }
+
+type ExpPath struct {
+	Path string
+	Exp  string
+}
+
+func TestShortenPegnetFilePath(t *testing.T) {
+	testPath(ExpPath{
+		"/home/billy/go/src/github.com/pegnet/pegnet/opr.go",
+		"pegnet/opr.go",
+	}, t)
+
+	testPath(ExpPath{
+		"/home/billy/go/src/github.com/notpegnet/notpegnet/opr.go",
+		"/home/billy/go/src/github.com/notpegnet/notpegnet/opr.go",
+	}, t)
+
+	testPath(ExpPath{
+		"opr.go",
+		"opr.go",
+	}, t)
+
+	testPath(ExpPath{
+		"/home/steven/go/src/github.com/pegnet/pegnet/opr/oneminer.go",
+		"pegnet/opr/oneminer.go",
+	}, t)
+
+	testPath(ExpPath{
+		"pegnet",
+		"pegnet",
+	}, t)
+
+	testPath(ExpPath{
+		"pegnet/test_pegnet.go",
+		"pegnet/test_pegnet.go",
+	}, t)
+
+	testPath(ExpPath{
+		"/home/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec",
+		"/home/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec/rec",
+	}, t)
+}
+
+func testPath(e ExpPath, t *testing.T) {
+	if f := ShortenPegnetFilePath(e.Path, "", 0); f != e.Exp {
+		t.Errorf("Exp %s, found %s", e.Exp, f)
+	}
+}


### PR DESCRIPTION
Trying to find where the errors come from is a pain. This tells you where
the error came from.

Eg:
```
FATA[0000] An error in OPR was encountered               caller="pegnet/opr/opr.go:72" error=test
```