### PR TITLE
PNT-126: Only keep top X miner records

### DIFF
--- a/cmd/cmdProvider.go
+++ b/cmd/cmdProvider.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// CmdFlagProvider is able to pull values from the command line, and replace default config
+// values.
+type CmdFlagProvider struct {
+	cmd *cobra.Command
+}
+
+func NewCmdFlagProvider(cmd *cobra.Command) *CmdFlagProvider {
+	d := new(CmdFlagProvider)
+	d.cmd = cmd
+
+	return d
+}
+
+func (c *CmdFlagProvider) Load() (map[string]string, error) {
+	settings := map[string]string{}
+
+	miners, _ := c.cmd.Flags().GetInt("miners")
+	if miners != -1 {
+		settings["Miner.NumberOfMiners"] = fmt.Sprintf("%d", miners)
+	}
+
+	top, _ := c.cmd.Flags().GetInt("top")
+	if top != -1 {
+		settings["Miner.RecordsPerBlock"] = fmt.Sprintf("%d", top)
+	}
+
+	return settings, nil
+}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+
+	_ "net/http/pprof"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// StartProfiler runs the go pprof tool
+// `go tool pprof http://localhost:6060/debug/pprof/profile`
+// https://golang.org/pkg/net/http/pprof/
+func StartProfiler(port int) {
+	runtime.SetBlockProfileRate(int(time.Second.Nanoseconds()))
+	url := fmt.Sprintf("localhost:%d", port)
+	log.Infof("Profiling on %s", url)
+	log.Println(http.ListenAndServe(url, nil))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,6 @@ var (
 	LogLevel        string
 	FactomdLocation string
 	WalletdLocation string
-	Miners          int
 	Timeout         uint
 	Network         string
 )
@@ -42,12 +41,22 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&LogLevel, "log", "info", "Change the logging level. Can choose from 'trace', 'debug', 'info', 'warn', 'error', or 'fatal'")
 	rootCmd.PersistentFlags().StringVar(&FactomdLocation, "s", "localhost:8088", "IPAddr:port# of factomd API to use to access blockchain (default localhost:8088)")
 	rootCmd.PersistentFlags().StringVar(&WalletdLocation, "w", "localhost:8089", "IPAddr:port# of factom-walletd API to use to create transactions (default localhost:8089)")
-	rootCmd.PersistentFlags().IntVar(&Miners, "miners", 0, "Change the number of miners being run (default 0)")
 	rootCmd.PersistentFlags().UintVar(&Timeout, "timeout", 90, "The time (in seconds) that the miner tolerates the downtime of the factomd API before shutting down")
 	rootCmd.PersistentFlags().StringVar(&Network, "network", "test", "The pegnet network to target. <Main|Test>")
 
+	// Flags that affect the config file. Should not be loaded into globals
+	rootCmd.PersistentFlags().Int("miners", -1, "Change the number of miners being run (default to config file)")
+	rootCmd.PersistentFlags().Int("top", -1, "Change the number opr records written per block (default to config file)")
+
+	// Persist flags that run in PreRun, and not in the config
+	rootCmd.PersistentFlags().Bool("profile", false, "GoLang profiling")
+	rootCmd.PersistentFlags().Int("profileport", 7060, "Change profiling port (default 16060)")
+
+	// Initialize the config file with the config, then with cmd flags
+	rootCmd.PersistentPreRunE = rootPreRunSetup
+
 	// Run a few functions (in the order specified) to initialize some globals
-	cobra.OnInitialize(initLogger, initFactomdLocs, initConfig)
+	cobra.OnInitialize(initLogger, initFactomdLocs)
 }
 
 // The cli enter point
@@ -57,29 +66,11 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO: Do we really want to init the miner by default?
 		//  	 Not like `pegnet -service=miner` or something?
-		_, err := Config.String("Miner.Protocol")
-		if err != nil {
-			log.WithError(err).Fatal("Failed to read miner protocol from config")
-		}
-		configMiners, err := Config.Int("Miner.NumberOfMiners")
-		if err != nil {
-			log.WithError(err).Fatal("Failed to read number of miners from config")
-		}
 
-		identity, err := Config.String("Miner.IdentityChain")
-		if err != nil {
-			log.WithError(err).Fatal("Failed to read the identity chain or miner id")
-		}
-
-		valid, _ := regexp.MatchString("^[a-zA-Z0-9,]+$", identity)
-		if !valid {
-			log.Fatal("Only alphanumeric characters and commas are allowed in the identity")
-		}
+		ValidateConfig(Config) // Will fatal log if it fails
 
 		// Default to config options if cli flags aren't specified
-		if Miners == 0 {
-			Miners = configMiners
-		}
+		miners, _ := Config.Int("Miner.NumberOfMiners")
 
 		monitor := common.GetMonitor()
 		monitor.SetTimeout(time.Duration(Timeout) * time.Second)
@@ -98,8 +89,8 @@ var rootCmd = &cobra.Command{
 
 		go controlPanel.ServeControlPanel(Config, monitor)
 
-		if Miners > 0 {
-			miners := pegnetMining.InitMiners(Miners, Config, monitor, grader)
+		if miners > 0 {
+			miners := pegnetMining.InitMiners(Config, monitor, grader)
 			for _, m := range miners[:len(miners)-1] {
 				go m.LaunchMiningThread(false)
 			}
@@ -112,6 +103,28 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+}
+
+// Do w/e config validation we want. We can check the error if we care about it
+func ValidateConfig(config *config.Config) {
+	_, err := config.String("Miner.Protocol")
+	if err != nil {
+		log.WithError(err).Fatal("failed to read miner protocol from config")
+	}
+	_, err = config.Int("Miner.NumberOfMiners")
+	if err != nil {
+		log.WithError(err).Fatal("failed to read number of miners from config")
+	}
+
+	identity, err := config.String("Miner.IdentityChain")
+	if err != nil {
+		log.WithError(err).Fatal("failed to read the identity chain or miner id")
+	}
+
+	valid, _ := regexp.MatchString("^[a-zA-Z0-9,]+$", identity)
+	if !valid {
+		log.WithError(err).Fatal("only alphanumeric characters and commas are allowed in the identity")
 	}
 }
 
@@ -137,7 +150,8 @@ func initFactomdLocs() {
 	factom.SetWalletServer(WalletdLocation)
 }
 
-func initConfig() {
+func rootPreRunSetup(cmd *cobra.Command, args []string) error {
+	// Config setup
 	u, err := user.Current()
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read current user's name")
@@ -145,7 +159,16 @@ func initConfig() {
 	userPath := u.HomeDir
 	configFile := fmt.Sprintf("%s/.%s/defaultconfig.ini", userPath, "pegnet")
 	iniFile := config.NewINIFile(configFile)
-	Config = config.NewConfig([]config.Provider{iniFile})
+	flags := NewCmdFlagProvider(cmd)
+	Config = config.NewConfig([]config.Provider{iniFile, flags})
+
+	// Profiling setup
+	if on, _ := cmd.Flags().GetBool("profile"); on {
+		p, _ := cmd.Flags().GetInt("profileport")
+		go StartProfiler(p)
+	}
+
+	return nil
 }
 
 // https://github.com/spf13/cobra/blob/master/bash_completions.md

--- a/common/config.go
+++ b/common/config.go
@@ -33,6 +33,8 @@ func NewUnitTestConfigProvider() *UnitTestConfigProvider {
 [Miner]
   NetworkType=LOCAL
   NumberOfMiners=15
+# The number of records to submit per block. The top N records are chosen, where N is the config value
+  RecordsPerBlock=10
   Protocol=PegNet 
   Network=TestNet
 

--- a/defaultconfig.ini
+++ b/defaultconfig.ini
@@ -46,6 +46,8 @@
 [Miner]
   NetworkType=LOCAL
   NumberOfMiners=15
+# The number of records to submit per block. The top N records are chosen, where N is the config value
+  RecordsPerBlock=10
   Protocol=PegNet 
   Network=TestNet
 

--- a/opr/aggregator_test.go
+++ b/opr/aggregator_test.go
@@ -1,0 +1,150 @@
+package opr_test
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	. "github.com/pegnet/pegnet/opr"
+)
+
+func TestMergeRankings(t *testing.T) {
+	t.Run("Merge vector", func(t *testing.T) {
+		total := 100
+		rs := make([]*NonceRanking, total)
+		for i := range rs {
+			rs[i] = NewNonceRanking(1)
+			rs[i].AddNonce([]byte{}, uint64(i+1), []string{})
+		}
+
+		m := MergeNonceRankings(10, rs...)
+		if !verifyOrder(m.GetNonces()) {
+			t.Errorf("not ordered")
+		}
+
+		l := m.GetNonces()
+		for i := 0; i < len(l); i++ {
+			if l[i].Difficulty != uint64(total-i) {
+				t.Errorf("best diff did not win, exp %d, found %d", uint64(total-i), l[i].Difficulty)
+			}
+		}
+	})
+}
+
+func TestAggregatorOrder(t *testing.T) {
+	t.Run("random adds", func(t *testing.T) {
+		list := NewNonceRanking(100)
+		vals := make([]uint64, 5000)
+		for i := range vals {
+			vals[i] = rand.Uint64()
+		}
+
+		for i := 0; i < len(vals); i++ {
+			list.AddNonce([]byte{}, vals[i], []string{})
+		}
+
+		l := list.GetNonces()
+		for i := 1; i < len(l); i++ {
+			if l[i-1].Difficulty < l[i].Difficulty {
+				t.Errorf("Not ordered")
+			}
+		}
+	})
+
+	t.Run("vectored", func(t *testing.T) {
+		list := NewNonceRanking(10)
+		total := 100
+		for i := total; i >= 0; i-- {
+			list.AddNonce([]byte{}, uint64(i), []string{})
+		}
+
+		l := list.GetNonces()
+		for i := 0; i < len(l); i++ {
+			if l[i].Difficulty != uint64(total-i) {
+				t.Errorf("Not ordered")
+			}
+		}
+	})
+}
+
+func verifyOrder(l []*UniqueOPRData) bool {
+	for i := 1; i < len(l); i++ {
+		if l[i-1].Difficulty < l[i].Difficulty {
+			return false
+		}
+	}
+	return true
+}
+
+/* The performance impact to mining on each iteration of using a top X list vs
+ * Notes these numbers change run to run, but it's so minor compared to the hashing function
+ * BenchmarkNonceAdding/Only_keeping_best_(control)-8         	20000000	       26.7 ns/op
+ * BenchmarkNonceAdding/Always_Adding_Nonce_(worst_case)-8    	20000000	        57.9 ns/op
+ * BenchmarkNonceAdding/Never_Adding_Nonce_(best_case)-8      	200000000	         6.34 ns/op
+ * BenchmarkNonceAdding/Randomly_Adding_Nonce_(avg_case?ish)-8         	50000000	        32.0 ns/op
+ */
+
+func BenchmarkNonceAdding(b *testing.B) {
+	b.Run("Only keeping best (control)", benchmarkControl)
+	b.Run("Always Adding Nonce (worst case)", benchmarkAlwaysAddingNonce)
+	b.Run("Never Adding Nonce (best case)", benchmarkNeverAddingNonce)
+	b.Run("Randomly Adding Nonce (avg case?ish)", benchmarkRandomlyAddingNonce)
+}
+
+// benchmarkAlwaysAddingNonce will be the worst case where each nonce has a higher difficulty
+func benchmarkControl(b *testing.B) {
+	diffs := make([]uint64, b.N)
+	for i := range diffs {
+		diffs[i] = rand.Uint64()
+	}
+
+	best := uint64(0)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		if diffs[i] > best {
+			best = diffs[i]
+		}
+	}
+}
+
+// benchmarkAlwaysAddingNonce will be the worst case where each nonce has a higher difficulty
+func benchmarkAlwaysAddingNonce(b *testing.B) {
+	list := NewNonceRanking(10)
+	diffs := make([]uint64, b.N)
+	for i := range diffs {
+		diffs[i] = uint64(i)
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		list.AddNonce([]byte{}, diffs[i], []string{})
+	}
+}
+
+// benchmarkAlwaysAddingNonce will be the best case where we do no-ops
+func benchmarkNeverAddingNonce(b *testing.B) {
+	list := NewNonceRanking(1)
+	list.AddNonce([]byte{}, math.MaxUint64, []string{})
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		list.AddNonce([]byte{}, uint64(i), []string{})
+	}
+}
+
+// benchmarkAlwaysAddingNonce will be the avg case..ish
+func benchmarkRandomlyAddingNonce(b *testing.B) {
+	list := NewNonceRanking(10)
+	diffs := make([]uint64, b.N)
+	for i := range diffs {
+		diffs[i] = rand.Uint64()
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		list.AddNonce([]byte{}, diffs[i], []string{})
+	}
+}

--- a/pegnetMining/entryWriter.go
+++ b/pegnetMining/entryWriter.go
@@ -1,0 +1,175 @@
+package pegnetMining
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/FactomProject/factom"
+	"github.com/cenkalti/backoff"
+	"github.com/pegnet/pegnet/common"
+	"github.com/pegnet/pegnet/opr"
+	log "github.com/sirupsen/logrus"
+	"github.com/zpatrick/go-config"
+)
+
+// EntryWriter writes the best OPRs to factom
+type EntryWriter struct {
+	Keep int
+	// We need an opr tempalate to make the entries
+	oprTemplate *opr.OraclePriceRecord
+	ec          *factom.ECAddress
+	config      *config.Config
+
+	minerLists chan *opr.NonceRanking
+	miners     int
+
+	Next *EntryWriter
+
+	sync.Mutex
+	sync.Once
+}
+
+func NewEntryWriter(config *config.Config, keep int) *EntryWriter {
+	w := new(EntryWriter)
+	w.Keep = keep
+	w.minerLists = make(chan *opr.NonceRanking, keep)
+	w.config = config
+
+	return w
+}
+
+// populateECAddress only needs to be called once
+func (w *EntryWriter) populateECAddress() error {
+	// Get the Entry Credit Address that we need to write our OPR records.
+	if ecadrStr, err := w.config.String("Miner.ECAddress"); err != nil {
+		return err
+	} else {
+		ecAdr, err := factom.FetchECAddress(ecadrStr)
+		if err != nil {
+			return err
+		}
+		w.ec = ecAdr
+	}
+	return nil
+}
+
+// NextBlockWriter gets the next block writer to use for the miner.
+//	Because all miners will share a block writer, all miners will call
+//	this function. We make all shared entry writers share the next one.
+func (w *EntryWriter) NextBlockWriter() *EntryWriter {
+	w.Lock()
+	defer w.Unlock()
+	if w.Next == nil {
+		w.Next = NewEntryWriter(w.config, w.Keep)
+		w.Next.ec = w.ec
+	}
+	return w.Next
+}
+
+// AddMiner will add a miner to listen to for this block, and return the channel they
+// should talk to us on.
+func (w *EntryWriter) AddMiner() chan<- *opr.NonceRanking {
+	w.Lock()
+	defer w.Unlock()
+
+	w.miners++
+	return w.minerLists
+}
+
+// SetOPR is here because we need an opr to create the entry.
+// In reality the mining shouldn't couple the mining and entry creation so closely.
+func (w *EntryWriter) SetOPR(opr *opr.OraclePriceRecord) {
+	w.Lock()
+	defer w.Unlock()
+	if w.oprTemplate == nil {
+		w.oprTemplate = opr.CloneEntryData()
+	}
+}
+
+// CollectAndWrite will write the block when we collected all the miner data
+//	The blocking is mainly for unit tests.
+func (w *EntryWriter) CollectAndWrite(blocking bool) {
+	w.Do(func() {
+		if blocking {
+			w.collectAndWrite()
+		} else {
+			go w.collectAndWrite()
+		}
+	})
+}
+
+// collectAndWrite is idempotent
+func (w *EntryWriter) collectAndWrite() {
+	var aggregate []*opr.NonceRanking
+GatherListLoop:
+	for {
+		select {
+		case list := <-w.minerLists:
+			aggregate = append(aggregate, list)
+			if len(aggregate) == w.miners {
+				break GatherListLoop
+			}
+		}
+	}
+
+	final := opr.MergeNonceRankings(w.Keep, aggregate...)
+	nonces := final.GetNonces()
+	for _, u := range nonces {
+		err := w.writeMiningRecord(u)
+		if err != nil {
+			log.WithError(err).Error("Failed to write mining record")
+		}
+	}
+
+	dbht := int32(-1)
+	if w.oprTemplate != nil {
+		dbht = w.oprTemplate.Dbht
+	}
+
+	log.WithFields(log.Fields{
+		"hashrate":    common.Stats.GetHashRate(),
+		"difficulty":  common.FormatDiff(common.Stats.Difficulty, 10),
+		"miner_count": w.miners,
+		"height":      dbht,
+		"exp_records": w.Keep,
+		"records":     len(nonces),
+	}).Info("OPR Block Mined")
+	common.Stats.Clear()
+}
+
+func (w *EntryWriter) writeMiningRecord(unique *opr.UniqueOPRData) error {
+	if w.oprTemplate == nil {
+		return fmt.Errorf("no opr template")
+	}
+
+	operation := func() error {
+		var err1, err2 error
+		w.oprTemplate.FactomDigitalID = unique.FactomDigitalID
+		entry, err := w.oprTemplate.CreateOPREntry(unique.Nonce)
+		if err != nil {
+			return err
+		}
+
+		_, err1 = factom.CommitEntry(entry, w.ec)
+		_, err2 = factom.RevealEntry(entry)
+		if err1 == nil && err2 == nil {
+			return nil
+		}
+
+		return errors.New("Unable to commit entry to factom")
+	}
+
+	err := backoff.Retry(operation, common.PegExponentialBackOff())
+	if err != nil {
+		// TODO: Handle error in retry
+		return err
+	}
+	return nil
+}
+
+// Cancel will cancel a miner's write. If the miner was stopped, we should not expect his write
+func (w *EntryWriter) Cancel() {
+	w.miners--
+	w.minerLists <- nil
+}

--- a/pegnetMining/entryWriter_test.go
+++ b/pegnetMining/entryWriter_test.go
@@ -1,0 +1,38 @@
+package pegnetMining_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/pegnet/pegnet/common"
+	"github.com/pegnet/pegnet/opr"
+
+	. "github.com/pegnet/pegnet/pegnetMining"
+)
+
+func TestEntryWriter(t *testing.T) {
+	c := common.NewUnitTestConfig()
+	k := 3
+	w := NewEntryWriter(c, k)
+	miners := []chan<- *opr.NonceRanking{}
+	for i := 0; i < 10; i++ {
+		miners = append(miners, w.AddMiner())
+	}
+
+	go func() {
+		for _, m := range miners {
+			m <- randNonceRanking(k, 10)
+		}
+	}()
+
+	w.CollectAndWrite(true)
+
+}
+
+func randNonceRanking(keep, size int) *opr.NonceRanking {
+	n := opr.NewNonceRanking(keep)
+	for i := 0; i < size; i++ {
+		n.AddNonce([]byte{}, rand.Uint64(), []string{})
+	}
+	return n
+}

--- a/pegnetMining/miner_test.go
+++ b/pegnetMining/miner_test.go
@@ -34,8 +34,9 @@ func TestMinerCleanup(t *testing.T) {
 
 	g := opr.NewFakeGrader()
 	m := common.NewFakeMonitor()
+	c := common.NewUnitTestConfig()
 
-	p := NewPegnetMiner(common.NewUnitTestConfig(), m, g)
+	p := NewPegnetMiner(c, m, g, NewEntryWriter(c, 3))
 	t.Run("Before first event stop", func(t *testing.T) {
 		n := runtime.NumGoroutine()
 


### PR DESCRIPTION
All miners will collect their top X records, then those lists are merged
and only the top X from the set of miners is kept and written to factom.

Also:
- Made a cmd line flag parser to overwrite configs, so we only need cfg
- Added profiling option