### PR TITLE
Pnt 72 switch to f axxxx addresses

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -59,7 +59,7 @@ var getEncoding = &cobra.Command{
 		if len(args) == 2 {
 			asset = strings.ToLower(args[1])
 		}
-		assets, err := common.ConvertUserFctToUserPegNetAssets(os.Args[2])
+		assets, err := common.ConvertFCTtoAllPegNetAssets(os.Args[2])
 		if err != nil {
 			// TODO: Verify this error message?
 			fmt.Println("Must provide a valid FCT public key")
@@ -99,7 +99,7 @@ var newAddress = &cobra.Command{
 			return
 		}
 		fmt.Print(fa.String(), "\n\n")
-		assets, err := common.ConvertUserFctToUserPegNetAssets(fa.String())
+		assets, err := common.ConvertFCTtoAllPegNetAssets(fa.String())
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/common/common.go
+++ b/common/common.go
@@ -3,7 +3,6 @@
 package common
 
 import (
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -51,11 +50,10 @@ func init() {
 	for network, add := range BurnAddresses {
 		if !factom.IsValidAddress(add) {
 			// If it is not valid, could be checksum related
-			newAddr, err := ConvertUserStrFctEcToAddress(add)
+			raw, err := ConvertAnyFactomAdrToRaw(add)
 			if err == nil {
 				// Try and fix it, then suggest the new checksum
-				raw, _ := hex.DecodeString(newAddr)
-				burn := ConvertECAddressToUser(raw)
+				burn := ConvertRawToEC(raw)
 				if factom.IsValidAddress(burn) {
 					panic(fmt.Sprintf("[%s] %s is not a valid address, but %s is", network, add, burn))
 				}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,3 +1,0 @@
-// Copyright (c) of parts are held by the various contributors (see the CLA)
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
-package common_test

--- a/common/factomUtils.go
+++ b/common/factomUtils.go
@@ -16,7 +16,10 @@ func ComputeChainIDFromFields(fields [][]byte) []byte {
 	hs := sha256.New()
 	for _, id := range fields {
 		h := sha256.Sum256(id)
-		hs.Write(h[:])
+		_, err := hs.Write(h[:])
+		if err != nil {
+			panic("Unexpected write failure")
+		}
 	}
 	chainID := hs.Sum(nil)
 	return chainID

--- a/common/utils.go
+++ b/common/utils.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 
 	"github.com/FactomProject/btcutil/base58"
@@ -65,12 +64,12 @@ func CheckPrefix(name string) bool {
 
 }
 
-// ConvertRawAddrToPeg()
+// ConvertRawToPegNetAsset()
 // Converts a raw RCD1 address into a wallet friendly address that can be used to
 // convert assets, check balances, and send tokens.  While the underlying private key can be
 // used to hold Factoids or any token in the PegNet, users need addresses that create a
 // barrier to mistakes that can lead to sending the wrong tokens to the wrong addresses
-func ConvertRawAddrToPeg(prefix string, adr []byte) (string, error) {
+func ConvertRawToPegNetAsset(prefix string, adr []byte) (string, error) {
 
 	// Make sure the prefix is valid.
 	if !CheckPrefix(prefix) {
@@ -90,11 +89,11 @@ func ConvertRawAddrToPeg(prefix string, adr []byte) (string, error) {
 // Convert a human/wallet address to the raw underlying address.  Verifies the checksum and
 // the validity of the prefix.  Returns the prefix, the raw address, and error.
 //
-func ConvertPegAddrToRaw(adr string) (prefix string, rawAdr []byte, err error) {
+func ConvertPegNetAssetToRaw(adr string) (prefix string, rawAdr []byte, err error) {
 	adrLen := len(adr)
 	if adrLen < 42 || len(adr) > 56 {
-		return "", nil, errors.New(
-			fmt.Sprintf("valid pegNet token addresses are 44 to 56 characters in length. len(adr)=%d ", adrLen))
+		return "", nil,
+			fmt.Errorf("valid pegNet token addresses are 44 to 56 characters in length. len(adr)=%d ", adrLen)
 	}
 
 	prefix = adr[:4]
@@ -112,7 +111,7 @@ func ConvertPegAddrToRaw(adr string) (prefix string, rawAdr []byte, err error) {
 
 	hash := sha256.Sum256(append(append([]byte(prefix), '_'), rawAdr...))
 	hash = sha256.Sum256(hash[:])
-	if bytes.Compare(hash[:4], chksum) != 0 {
+	if !bytes.Equal(hash[:4], chksum) {
 		return "", nil, errors.New("checksum failure")
 	}
 
@@ -120,10 +119,10 @@ func ConvertPegAddrToRaw(adr string) (prefix string, rawAdr []byte, err error) {
 
 }
 
-// PegTAdrIsValid()
+// ValidatePegNetAssetAddress()
 // Check that the given human/wallet PegNet address is valid.
-func PegTAdrIsValid(adr string) error {
-	_, _, err := ConvertPegAddrToRaw(adr)
+func ValidatePegNetAssetAddress(adr string) error {
+	_, _, err := ConvertPegNetAssetToRaw(adr)
 	return err
 }
 
@@ -146,15 +145,13 @@ func RandomByteSliceOfLen(sliceLen int) []byte {
 //
 //  Creates the binary form.  Just needs the conversion to base58
 //  for display.
-func ConvertFctAddressToUser(addr []byte) string {
+func ConvertRawToFCT(addr []byte) string {
 	dat := make([]byte, 0, 64)
-	dat = append(dat, 0x5f, 0xb1)
+	dat = append(dat, fcPubPrefix...)
 	dat = append(dat, addr...)
 	hash := sha256.Sum256(dat)
 	sha256d := sha256.Sum256(hash[:])
-	userd := []byte{0x5f, 0xb1}
-	userd = append(userd, addr...)
-	userd = append(userd, sha256d[:4]...)
+	userd := append(dat, sha256d[:4]...)
 	return base58.Encode(userd)
 }
 
@@ -163,22 +160,20 @@ func ConvertFctAddressToUser(addr []byte) string {
 //
 //  Creates the binary form.  Just needs the conversion to base58
 //  for display.
-func ConvertECAddressToUser(addr []byte) string {
+func ConvertRawToEC(addr []byte) string {
 	dat := make([]byte, 0, 64)
-	dat = append(dat, 0x59, 0x2a)
+	dat = append(dat, ecPubPrefix...)
 	dat = append(dat, addr...)
 	hash := sha256.Sum256(dat)
 	sha256d := sha256.Sum256(hash[:])
-	userd := []byte{0x59, 0x2a}
-	userd = append(userd, addr...)
-	userd = append(userd, sha256d[:4]...)
+	userd := append(dat, sha256d[:4]...)
 	return base58.Encode(userd)
 }
 
 // Convert a User facing Factoid address
 // to the raw form.  We do what validation we can here, and
 // return an error if the Factoid address is not valid
-func ConvertFctAddressToRaw(userFAddr string) (raw []byte, err error) {
+func ConvertFCTtoRaw(userFAddr string) (raw []byte, err error) {
 	if len(userFAddr) != 52 {
 		return nil, errors.New("invalid length of a factoid address")
 	}
@@ -202,25 +197,25 @@ func ConvertFctAddressToRaw(userFAddr string) (raw []byte, err error) {
 // or their Private Key representations
 // to the regular form.  Note validation must be done
 // separately!
-func ConvertUserStrFctEcToAddress(userFAddr string) (string, error) {
+func ConvertAnyFactomAdrToRaw(userFAddr string) ([]byte, error) {
 	v := base58.Decode(userFAddr)
 	switch {
-	case bytes.Compare(v[:2], fcPubPrefix) == 0:
-	case bytes.Compare(v[:2], fcSecPrefix) == 0:
-	case bytes.Compare(v[:2], ecPubPrefix) == 0:
-	case bytes.Compare(v[:2], ecSecPrefix) == 0:
+	case bytes.Equal(v[:2], fcPubPrefix):
+	case bytes.Equal(v[:2], fcSecPrefix):
+	case bytes.Equal(v[:2], ecPubPrefix):
+	case bytes.Equal(v[:2], ecSecPrefix):
 	default:
-		return "", errors.New("unknown prefix")
+		return nil, errors.New("unknown prefix")
 	}
-	return hex.EncodeToString(v[2:34]), nil
+	return v[2:34], nil
 }
 
 // Convert a User facing FCT address to all of its PegNet
 // asset token User facing forms.
-func ConvertUserFctToUserPegNetAssets(userFctAddr string) (assets []string, err error) {
+func ConvertFCTtoAllPegNetAssets(userFctAddr string) (assets []string, err error) {
 	raw := base58.Decode(userFctAddr)[2:34]
 	cvt := func(asset string) (passet string) {
-		passet, err = ConvertRawAddrToPeg(asset, raw)
+		passet, err = ConvertRawToPegNetAsset(asset, raw)
 		if err != nil {
 			panic(err)
 		}
@@ -236,16 +231,16 @@ func ConvertUserFctToUserPegNetAssets(userFctAddr string) (assets []string, err 
 }
 
 func ConvertFCTtoPNT(network string, userFAdr string) (pnt string, err error) {
-	raw, err := ConvertFctAddressToRaw(userFAdr)
+	raw, err := ConvertFCTtoRaw(userFAdr)
 	if err != nil {
 		return "", err
 	}
 
 	switch network {
 	case "TestNet":
-		pnt, err = ConvertRawAddrToPeg("tPNT", raw)
+		pnt, err = ConvertRawToPegNetAsset("tPNT", raw)
 	case "MainNet":
-		pnt, err = ConvertRawAddrToPeg("pPNT", raw)
+		pnt, err = ConvertRawToPegNetAsset("pPNT", raw)
 	}
 	if err != nil {
 		log.Errorf("Invalid RCD, could not create PNT address")

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -33,14 +33,14 @@ func TestConvertFctToPegAssets(t *testing.T) {
 		fmt.Println(fct)
 		raw = factoid.ConvertUserStrToAddress(fct)
 		fmt.Printf("%x\n", raw)
-		pnt, err := ConvertRawToPegNetAsset("pPNT", raw)
+		pnt, err := ConvertRawToPegNetAsset("PNT", raw)
 		if err != nil {
 			t.Fatal(fa, " ", err)
 		}
 		fmt.Println(pnt)
 		pre, raw2, err := ConvertPegNetAssetToRaw(pnt)
-		if pre != "pPNT" || !bytes.Equal(raw, raw2) || err != nil {
-			t.Fatal("Round trip failed with pPNT")
+		if pre != "PNT" || !bytes.Equal(raw, raw2) || err != nil {
+			t.Fatal("Round trip failed with PNT")
 		}
 		fmt.Printf("%x\n", raw2)
 		tpnt, err := ConvertRawToPegNetAsset("tPNT", raw)
@@ -122,7 +122,7 @@ func TestConvertRawAddrToPegT(t *testing.T) {
 		return nil
 	}
 
-	if err := ConvertToHuman("pPNT"); err != nil {
+	if err := ConvertToHuman("PNT"); err != nil {
 		t.Error(err)
 	}
 	if err := ValidatePegNetAssetAddress(HumanAdr); err != nil {
@@ -166,7 +166,7 @@ func TestConvertRawAddrToPegT(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := ConvertToHuman("pPNT"); err != nil {
+	if err := ConvertToHuman("PNT"); err != nil {
 		t.Error(err)
 	}
 	if err := ValidatePegNetAssetAddress(HumanAdr); err != nil {
@@ -195,13 +195,13 @@ func TestConvertRawAddrToPegT(t *testing.T) {
 	if err := ConvertToHuman("YEN"); err == nil {
 		t.Error(err)
 	}
-	if err := ConvertToHuman("PNT"); err == nil {
+	if err := ConvertToHuman("pPNT"); err == nil {
 		t.Error(err)
 	}
 
 	setAdr("2222222222222222222222222222222222222222222222222222222222222222")
 
-	if err := ConvertToHuman("pPNT"); err != nil {
+	if err := ConvertToHuman("PNT"); err != nil {
 		t.Error(err)
 	}
 	if err := ValidatePegNetAssetAddress(HumanAdr); err != nil {
@@ -213,7 +213,7 @@ func TestConvertRawAddrToPegT(t *testing.T) {
 
 	setAdr("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 
-	if err := ConvertToHuman("pPNT"); err != nil {
+	if err := ConvertToHuman("PNT"); err != nil {
 		t.Error(err)
 	}
 	if err := ValidatePegNetAssetAddress(HumanAdr); err != nil {

--- a/controlPanel/controlPanel.go
+++ b/controlPanel/controlPanel.go
@@ -2,6 +2,7 @@ package controlPanel
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/alexandrevicenzi/go-sse"
@@ -35,18 +36,27 @@ func ServeControlPanel(config *config.Config, monitor *common.Monitor, statTrack
 	// Register with /events endpoint.
 	http.Handle("/events/", s)
 
+	network, err := config.String("Miner.Network")
+	if err != nil {
+		panic(fmt.Sprintf("Do not have a proper network in the config file: %v", err))
+	}
+
 	// Dispatch messages to common channel
 	go func() {
 		var CurrentHashRate uint64
 		var CurrentDifficulty uint64
-		var CoinbasePNTAddress string
+		var CoinbaseAddress string
 
-		if str, err := config.String("Miner.CoinbasePNTAddress"); err != nil {
-			log.Fatal("config file has no Coinbase PNT Address")
+		if str, err := config.String("Miner.CoinbaseAddress"); err != nil {
+			log.Fatal("config file has no Coinbase Address")
 		} else {
-			CoinbasePNTAddress = str
+			CoinbaseAddress = str
 		}
 
+		CoinbasePNTAddress, err := common.ConvertFCTtoPNT(network, CoinbaseAddress)
+		if err != nil {
+			panic("no valid coinbase address in the config file")
+		}
 		// TODO: Include states from statTracker
 
 		for {

--- a/defaultconfig.ini
+++ b/defaultconfig.ini
@@ -58,8 +58,7 @@
   # For LOCAL network testing, FCT private key is
   # Fs3E9gV6DXsYzf7Fqx1fVBQPQXV695eP3k5XbmHEZVRLkMdD9qCK
   FCTAddress=FA2jK2HcLnRdS94dEcU27rF3meoJfpUcZPSinpb7AwQvPRY6RL1Q
-
-  CoinbasePNTAddress=tPNT_mEU1i4M5rn7bnrxNKdVVf4HXLG15Q798oaVAMrXq7zdbhQ9pv
+  CoinbaseAddress=FA2jK2HcLnRdS94dEcU27rF3meoJfpUcZPSinpb7AwQvPRY6RL1Q
   IdentityChain=prototype
 [Oracle]
   APILayerKey=f6c9765ef81279e8891d40e34ef7ab01

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/pegnet/LXRHash v0.0.0-20190701014124-2218ebac7160
 	github.com/prometheus/client_golang v1.0.0 // indirect
+	github.com/prometheus/common v0.4.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,9 @@ github.com/FactomProject/serveridentity v0.0.0-20180611231115-cf42d2aa8deb h1:qU
 github.com/FactomProject/serveridentity v0.0.0-20180611231115-cf42d2aa8deb/go.mod h1:qPNpznGlx4PdRmEL7I25U/zQHrbMK1h0Az8FYahuYdo=
 github.com/FactomProject/web v0.1.0 h1:M136UkW3h/V8hH7h+s7qqm3GGSrKGKyXi6p94Z/AgPw=
 github.com/FactomProject/web v0.1.0/go.mod h1:wiLhlN8amF4dalkSy+u75C3xsXaesSHy2cph6b/8PrI=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexandrevicenzi/go-sse v0.0.0-20190531224209-805eefa457e7 h1:HF2BoTaOEJzRl1WV+epnYM+kGi4DD87mVyQlWbkVLgA=
 github.com/alexandrevicenzi/go-sse v0.0.0-20190531224209-805eefa457e7/go.mod h1:BLBuvd1uY9dCX660zu1fzsmr0Cqt3VPqK1e5fPfV6wc=
@@ -228,6 +230,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/opr/assetList_test.go
+++ b/opr/assetList_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/FactomProject/btcutil/base58"
 	"github.com/pegnet/pegnet/common"
 	"github.com/pegnet/pegnet/opr"
 	"github.com/zpatrick/go-config"
@@ -89,15 +88,10 @@ func TestOPRJsonMarshal(t *testing.T) {
 	}
 
 	c := config.NewConfig([]config.Provider{common.NewUnitTestConfigProvider()})
-	protocol, err1 := c.String("Miner.Protocol")
-	network, err2 := c.String("Miner.Network")
-	if err1 != nil || err2 != nil {
-		t.Error("Should have protocol and network")
-	}
-	o.OPRChainID = base58.Encode(common.ComputeChainIDFromStrings([]string{protocol, network, common.OPRChainTag}))
-	o.CoinbasePNTAddress, err = common.ConvertRawAddrToPeg("tPNT", common.RandomByteSliceOfLen(32))
-	if err != nil {
-		t.Error(err)
+	o.CoinbaseAddress = common.ConvertRawToFCT(common.RandomByteSliceOfLen(32))
+
+	for _, asset := range common.AllAssets {
+		o.Assets[asset] = rand.Float64() * 1000
 	}
 
 	if !o.Validate(c) {

--- a/opr/balances.go
+++ b/opr/balances.go
@@ -27,7 +27,7 @@ func init() {
 
 // ConvertAddress takes a human-readable address and extracts the prefix and RCD hash
 func ConvertAddress(address string) (prefix string, adr [32]byte, err error) {
-	prefix, adr2, err := common.ConvertPegAddrToRaw(address)
+	prefix, adr2, err := common.ConvertPegNetAssetToRaw(address)
 	if err != nil {
 		return
 	}

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -270,7 +270,6 @@ func GetEntryBlocks(config *config.Config) {
 			}
 		}
 	}
-	return
 }
 
 // GetPreviousOPRs returns the OPRs in highest-known block less than dbht.

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -74,6 +74,7 @@ func GradeBlock(list []*OraclePriceRecord) (graded []*OraclePriceRecord, sorted 
 		if binary.BigEndian.Uint64(v.Entry.ExtIDs[1]) != v.Difficulty {
 			// This is a falsely reported difficulty. There is nothing we can
 			// really do. Maybe we should log.warn how many per block are 'malicious'?
+			_ = v
 		}
 	}
 
@@ -141,6 +142,8 @@ func GetEntryBlocks(config *config.Config) {
 	ebMutex.Lock()
 	defer ebMutex.Unlock()
 
+	network, err := config.String("Miner.Network")
+	check(err)
 	p, err := config.String("Miner.Protocol")
 	check(err)
 	n, err := config.String("Miner.Network")
@@ -182,7 +185,9 @@ func GetEntryBlocks(config *config.Config) {
 				if err := json.Unmarshal(entry.Content, opr); err != nil {
 					continue // Doesn't unmarshal, then it isn't valid for sure.  Continue on.
 				}
-
+				if opr.CoinbasePNTAddress, err = common.ConvertFCTtoPNT(network, opr.CoinbaseAddress); err != nil {
+					continue
+				}
 				// Run some basic checks on the values.  If they don't check out, then ignore the entry
 				if !opr.Validate(config) {
 					continue

--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -174,11 +174,6 @@ func e1(difficulty uint64, data float64) gradeEntry {
 	return gradeEntry{id: uniqID(), difficulty: difficulty, data: data}
 }
 
-// entry with set id
-func e2(difficulty uint64, data float64, id string) gradeEntry {
-	return gradeEntry{id: id, difficulty: difficulty, data: data}
-}
-
 // generate the OPR test case from input and outcome
 func genTest(name string, entries []gradeEntry, results []string) (gt gradeTest) {
 	id = 0 // reset uniq id
@@ -256,13 +251,6 @@ func gradeCompare(ids []string, entries, winners, sorted []*OraclePriceRecord) e
 	}
 
 	return nil
-}
-
-func prettyPrint(a []*OraclePriceRecord) {
-	for _, e := range a {
-		fmt.Printf("[id=%s, grade=%f, diff=%d]", e.FactomDigitalID, e.Grade, e.Difficulty)
-	}
-	fmt.Println()
 }
 
 func TestGradeBlock(t *testing.T) {

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -125,7 +125,7 @@ func ShortenPegnetFilePath(path, acc string, depth int) (trimmed string) {
 // Validate performs sanity checks of the structure and values of the OPR.
 // It does not validate the winners of the previous block.
 func (opr *OraclePriceRecord) Validate(c *config.Config) bool {
-	
+
 	// Validate there are no 0's
 	for k, v := range opr.Assets {
 		if v == 0 && k != "PNT" { // PNT is exception until we get a value for it
@@ -134,11 +134,7 @@ func (opr *OraclePriceRecord) Validate(c *config.Config) bool {
 	}
 
 	// Validate all the Assets exists
-	if !opr.Assets.Contains(common.AllAssets) {
-		return false // Missing some assets!
-	}
-
-	return true
+	return opr.Assets.Contains(common.AllAssets)
 }
 
 // GetTokens creates an iterateable slice of Tokens containing all the currency values
@@ -330,8 +326,7 @@ func NewOpr(ctx context.Context, minerNumber int, dbht int32, c *config.Config, 
 func (opr *OraclePriceRecord) GetOPRecord(c *config.Config) {
 	opr.Config = c
 	//get asset values
-	var Peg polling.PegAssets
-	Peg = polling.PullPEGAssets(c)
+	Peg := polling.PullPEGAssets(c)
 	opr.SetPegValues(Peg)
 
 	var err error

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -59,7 +59,10 @@ func TestOPR_JSON_Marshal(t *testing.T) {
 	v, _ := json.Marshal(opr)
 	fmt.Println("len of entry", len(string(v)), "\n\n", string(v))
 	opr2 := NewOraclePriceRecord()
-	json.Unmarshal(v, &opr2)
+	err := json.Unmarshal(v, &opr2)
+	if err != nil {
+		t.Fail()
+	}
 	v2, _ := json.Marshal(opr2)
 	fmt.Println("\n\n", string(v2))
 	if string(v2) != string(v) {

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -33,7 +33,7 @@ func TestOPR_JSON_Marshal(t *testing.T) {
 		base58.Encode(LX.Hash([]byte("winner number 9"))),
 		base58.Encode(LX.Hash([]byte("winner number 10"))),
 	}
-	opr.CoinbasePNTAddress = "pPNT4wBqpZM9xaShSYTABzAf1i1eSHVbbNk2xd1x6AkfZiy366c620f"
+	opr.CoinbasePNTAddress = "PNT4wBqpZM9xaShSYTABzAf1i1eSHVbbNk2xd1x6AkfZiy366c620f"
 	opr.FactomDigitalID = "minerone"
 	opr.Assets["PNT"] = 2
 	opr.Assets["USD"] = 20


### PR DESCRIPTION
Against my sense of a more understandable view of the PegNet, the reward address is no longer the PNT_xxxx format address, but a FAxxxxx address.

The FAxxxxx address is now the address in the OPR record.

Because the tPNT_xxxx and PNT_xxx format is really useful in the PegNet code, the FA address is pulled from the config file, and converted into the PNT_xxx format within the OPR.  But the PNT_xxx is not part of the JSON marshalling, so the FAxxxxx address goes out to the OPR record.

This preserves the addressing, balance checking, management of the Test Network code and Main Network code, balances and addresses.  Striping all of all of this code from the code base would have been a huge engineering task, and all we would have gained is having to start from scratch with testing, and a loss of coded and check summed addresses (I believe) we will add back when this hits actual payment use cases and the miners.

---------------
Also fixed as part of address shuffling was the fact that PNT is the token on the main net for PegNet, not pPNT.

Also fixed as part of address shuffling is the rework of the naming used for the asset address conversion functions.  Made raw always []byte, made raw (for the RCD or hash of public key in the case of ECs) always referred to as raw.  Made everything "Covert<whatever>To<whatever>.
