### PR TITLE
Benchmarking GradeBlock

### DIFF
--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -5,12 +5,14 @@ package opr
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/common"
@@ -562,4 +564,121 @@ func TestGradeBlock(t *testing.T) {
 			}
 		})
 	}
+}
+
+// for BENCHMARKING grading, it's not important what the data is, we just need data
+// we need ASSETS, OPRHASH, DIFFICULTY, and SELFREPORTEDDIFFICULTY
+func makeBenchmarkOPR() *OraclePriceRecord {
+	o := new(OraclePriceRecord)
+	o.Assets = make(OraclePriceRecordAssetList)
+	for _, a := range common.AllAssets {
+		o.Assets[a] = rand.Float64() * 50
+	}
+	o.Nonce = make([]byte, 8) // random nonce
+	rand.Read(o.Nonce)
+	json, _ := json.Marshal(o)
+	o.OPRHash = LX.Hash(json)
+	o.EntryHash = json // FOR BENCHMARK ONLY
+	difficulty := ComputeDifficulty(o.OPRHash, o.Nonce)
+	o.SelfReportedDifficulty = make([]byte, 8)
+	binary.BigEndian.PutUint64(o.SelfReportedDifficulty, difficulty)
+
+	return o
+}
+
+func BenchmarkGradeBlock(b *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	LX.Init(0xfafaececfafaecec, 30, 256, 5)
+
+	var oprs []*OraclePriceRecord
+	for i := 0; i < 10000; i++ {
+		oprs = append(oprs, makeBenchmarkOPR())
+	}
+
+	b.Run("ten", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:10])
+		}
+	})
+	b.Run("fifty", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:50])
+		}
+	})
+	b.Run("200", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:200])
+		}
+	})
+	b.Run("500", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:500])
+		}
+	})
+	b.Run("1000", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:1000])
+		}
+	})
+	b.Run("5000", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:5000])
+		}
+	})
+	b.Run("10000", func(b *testing.B) { // 10k OPRs = ~17 tps on factom
+		for i := 0; i < b.N; i++ {
+			GradeBlock(oprs[:10000])
+		}
+	})
+
+}
+
+func BenchmarkOPRHash(b *testing.B) {
+	var oprs []*OraclePriceRecord
+	for i := 0; i < 10000; i++ {
+		oprs = append(oprs, makeBenchmarkOPR())
+	}
+	b.Run("opr hash for 10", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:10] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
+	b.Run("opr hash for 50", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:50] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
+	b.Run("opr hash for 200", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:200] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
+
+	b.Run("opr hash for 500", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:500] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
+	b.Run("opr hash for 1000", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:1000] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
+	b.Run("opr hash for 10000", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, o := range oprs[:10000] {
+				LX.Hash(o.EntryHash) // contains json
+			}
+		}
+	})
 }

--- a/opr/grading_test.go
+++ b/opr/grading_test.go
@@ -634,6 +634,9 @@ func BenchmarkGradeBlock(b *testing.B) {
 }
 
 func BenchmarkOPRHash(b *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	LX.Init(0xfafaececfafaecec, 30, 256, 5)
+
 	var oprs []*OraclePriceRecord
 	for i := 0; i < 10000; i++ {
 		oprs = append(oprs, makeBenchmarkOPR())


### PR DESCRIPTION
These benchmarks take a long time to run (~2 minutes), so here's my findings:

Benchmarking GradeBlock with 10 to 10000 OPR entries:
```
BenchmarkGradeBlock/ten-8                   3000            535030 ns/op
BenchmarkGradeBlock/fifty-8                  100          12260701 ns/op
BenchmarkGradeBlock/200-8                     30          39235576 ns/op
BenchmarkGradeBlock/500-8                     20          91805250 ns/op
BenchmarkGradeBlock/1000-8                    10         176410090 ns/op
BenchmarkGradeBlock/5000-8                     2         878550250 ns/op (~.87 seconds)
BenchmarkGradeBlock/10000-8                    1        1756100400 ns/op (~1.7 seconds)
```

Benchmarking calculating the LXRHash for 10 to 10,000 entries. Please note that for this test, the json is cached before the benchmark is run, so this is purely hashing the available data.
```
BenchmarkOPRHash/opr_hash_for_10-8                   100          21971257 ns/op
BenchmarkOPRHash/opr_hash_for_50-8                    10         103305910 ns/op
BenchmarkOPRHash/opr_hash_for_200-8                    3         411690200 ns/op (~.4 seconds)
BenchmarkOPRHash/opr_hash_for_500-8                    1        1025058600 ns/op (~1 second)
BenchmarkOPRHash/opr_hash_for_1000-8                   1        2067118200 ns/op (~2 seconds)
BenchmarkOPRHash/opr_hash_for_10000-8                  1        21027202700 ns/op (~21 seconds)
```

I picked 10,000 because that's around 16.666 TPS and we had a recent stress test on the testnet with about 15 TPS, so that's a conceivable number we have to deal with.

The cost of the grading algorithm (or rather, the cost of calculating the **difficulty**, which is 90% of the grading work) is negligible compared to the cost of having to calculate the OPR hash in the first place.
