### PR TITLE
Query coincap by ID vs asset rankings

### DIFF
--- a/polling/coincap.go
+++ b/polling/coincap.go
@@ -34,11 +34,37 @@ type CoinCapRecord struct {
 	VWAP24Hr          string `json:"vwap24Hr"`
 }
 
+// CoinCapIOCryptoAssetNames is used by coincapio to query for the crypto we care about
+var CoinCapIOCryptoAssetNames = map[string]string{
+	"XBT":  "bitcoin",
+	"ETH":  "ethereum",
+	"LTC":  "litecoin",
+	"RVN":  "ravencoin",
+	"XBC":  "bitcoin-cash",
+	"FCT":  "factom",
+	"BNB":  "binance-coin",
+	"XLM":  "stellar",
+	"ADA":  "cardano",
+	"XMR":  "monero",
+	"DASH": "dash",
+	"ZEC":  "zcash",
+	"DCR":  "decred",
+}
+
 func CallCoinCap(config *config.Config) (CoinCapResponse, error) {
 	var CoinCapResponse CoinCapResponse
 
+	ids := ""
+	sep := ""
+	// Need to append all the ids we care about for the call
+	for _, a := range common.CryptoAssets {
+		ids += sep + CoinCapIOCryptoAssetNames[a]
+		sep = ","
+	}
+
 	operation := func() error {
-		resp, err := http.Get("http://api.coincap.io/v2/assets?limit=500")
+		url := "http://api.coincap.io/v2/assets?ids=" + ids
+		resp, err := http.Get(url)
 		if err != nil {
 			log.WithError(err).Warning("Failed to get response from CoinCap")
 			return err

--- a/polling/coincap.go
+++ b/polling/coincap.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/cenkalti/backoff"
 	"github.com/pegnet/pegnet/common"
@@ -54,16 +55,14 @@ var CoinCapIOCryptoAssetNames = map[string]string{
 func CallCoinCap(config *config.Config) (CoinCapResponse, error) {
 	var CoinCapResponse CoinCapResponse
 
-	ids := ""
-	sep := ""
+	var ids []string
 	// Need to append all the ids we care about for the call
 	for _, a := range common.CryptoAssets {
-		ids += sep + CoinCapIOCryptoAssetNames[a]
-		sep = ","
+		ids = append(ids, CoinCapIOCryptoAssetNames[a])
 	}
 
 	operation := func() error {
-		url := "http://api.coincap.io/v2/assets?ids=" + ids
+		url := "http://api.coincap.io/v2/assets?ids=" + strings.Join(ids, ",")
 		resp, err := http.Get(url)
 		if err != nil {
 			log.WithError(err).Warning("Failed to get response from CoinCap")


### PR DESCRIPTION
Maybe I should move this list out? But it's specific to coincap.io so I put it with coincap.io specifically.