### PR TITLE
lxrhash init print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - os: linux
       script:
         - ./.gofmt.sh 
-        - go test -race -timeout 45m ./...
+        - travis_wait 50 go test -race -timeout 45m ./...
   allow_failures:
     - os: windows
 
@@ -30,12 +30,12 @@ cache:
     - $HOME/gopath/pkg/mod
 
 script:
-  - go test -race -timeout 45m ./...
+  - travis_wait 50 go test -race -timeout 45m ./...
 
 # GO111MODULE will force Go modules
 # This will be unnecessary when Go 1.13 lands.
 env:
-  - GO111MODULE=on LXRBITSIZE=25
+  - GO111MODULE=on
 
 # Modifies go get flags
 # Can be removed when factom@v1-rollup is merged into master 

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -10,10 +10,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -87,12 +85,8 @@ var lxInitializer sync.Once
 func InitLX() {
 	lxInitializer.Do(func() {
 		// This code will only be executed ONCE, no matter how often you call it
-		if size, err := strconv.Atoi(os.Getenv("LXRBITSIZE")); err == nil && size >= 8 && size <= 30 {
-			LX.Init(0xfafaececfafaecec, uint64(size), 256, 5)
-		} else {
-			LX.Init(0xfafaececfafaecec, 30, 256, 5)
-		}
-
+		LX.Verbose(true)
+		LX.Init(0xfafaececfafaecec, 30, 256, 5)
 	})
 }
 


### PR DESCRIPTION
Prints lxrhash progress on first run.

Removes env variable check for bitsize.

closes: https://github.com/pegnet/pegnet/issues/170