### PR TITLE
CLI config filepath flag

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -83,7 +83,7 @@ func getPerformance(params interface{}) (*PerformanceResult, *Error) {
 				if i <= 50 {
 					difficultyPlacementsCount += 1
 					difficultyPlacementsSum += int64(i + 1)
-					for k, _ := range difficultyPlacements {
+					for k := range difficultyPlacements {
 						if i <= k {
 							difficultyPlacements[k] += 1
 						}
@@ -97,7 +97,7 @@ func getPerformance(params interface{}) (*PerformanceResult, *Error) {
 				rewards += int64(opr.GetRewardFromPlace(i))
 				gradingPlacementsCount += 1
 				gradingPlacementsSum += int64(i + 1)
-				for k, _ := range gradingPlacements {
+				for k := range gradingPlacements {
 					if i+1 <= k {
 						gradingPlacements[k] += 1
 					}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
-	"path/filepath"
 
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/api"
@@ -165,7 +165,7 @@ func rootPreRunSetup(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read current user's name")
 	}
- 
+
 	configFile := fmt.Sprintf("%s/.pegnet/defaultconfig.ini", u.HomeDir)
 	customPath, _ := cmd.Flags().GetString("config")
 	if customPath != "" {
@@ -175,7 +175,7 @@ func rootPreRunSetup(cmd *cobra.Command, args []string) error {
 			log.Info("Using config file: ", configFile)
 		}
 	}
-	
+
 	iniFile := config.NewINIFile(configFile)
 	flags := NewCmdFlagProvider(cmd)
 	Config = config.NewConfig([]config.Provider{iniFile, flags})


### PR DESCRIPTION
Adds `--config` to the cli.

Will take either an absolute or relative filepath. 

closes: https://github.com/pegnet/pegnet/issues/175