### PR TITLE
lxr hash init print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - os: linux
       script:
         - ./.gofmt.sh 
-        - go test -race -timeout 45m ./...
+        - go test -timeout 45m ./...
   allow_failures:
     - os: windows
 
@@ -30,7 +30,7 @@ cache:
     - $HOME/gopath/pkg/mod
 
 script:
-  - go test -race -timeout 45m ./...
+  - go test -timeout 45m ./...
 
 # GO111MODULE will force Go modules
 # This will be unnecessary when Go 1.13 lands.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - os: linux
       script:
         - ./.gofmt.sh 
-        - go test -timeout 45m ./...
+        - go test -race -timeout 45m ./...
   allow_failures:
     - os: windows
 
@@ -30,7 +30,7 @@ cache:
     - $HOME/gopath/pkg/mod
 
 script:
-  - go test -timeout 45m ./...
+  - go test -race -timeout 45m ./...
 
 # GO111MODULE will force Go modules
 # This will be unnecessary when Go 1.13 lands.

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -87,6 +87,7 @@ var lxInitializer sync.Once
 func InitLX() {
 	lxInitializer.Do(func() {
 		// This code will only be executed ONCE, no matter how often you call it
+		LX.Verbose(true)
 		if size, err := strconv.Atoi(os.Getenv("LXRBITSIZE")); err == nil && size >= 8 && size <= 30 {
 			LX.Init(0xfafaececfafaecec, uint64(size), 256, 5)
 		} else {


### PR DESCRIPTION
Prints lxrhash progress on first run.

~Removes env variable check for bitsize.~

Keeping bitsize until there's a hashmap cached on master to draw from for new branches.

~Removed -race from tests also for now until it's all sorted, the flag makes hashmap creation 10x slower.~ fixed elsewhere

closes: https://github.com/pegnet/pegnet/issues/170