### PR TITLE
Updating go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/pegnet/LXRHash v0.0.0-20190729140347-d2f14f305498
+	github.com/pegnet/LXRHash v0.0.0-20190729193922-452b32b2d231
 	github.com/prometheus/client_golang v1.0.0 // indirect
 	github.com/prometheus/common v0.4.1
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/pegnet/LXRHash v0.0.0-20190726144200-a35b17bbf85c h1:/3H7wWMIg/X/vvnk
 github.com/pegnet/LXRHash v0.0.0-20190726144200-a35b17bbf85c/go.mod h1:0zBp9GFy9F77zuQbPkAmdUBRiptMaJ1V96eVFdMnXZA=
 github.com/pegnet/LXRHash v0.0.0-20190729140347-d2f14f305498 h1:ZgjNdJ13H5DEHDP2tixorcDed4CPDH1/S3dsUUv2xBo=
 github.com/pegnet/LXRHash v0.0.0-20190729140347-d2f14f305498/go.mod h1:0zBp9GFy9F77zuQbPkAmdUBRiptMaJ1V96eVFdMnXZA=
+github.com/pegnet/LXRHash v0.0.0-20190729193922-452b32b2d231 h1:/kqjIK3ufejdrpUwWdk0hdALErfY/37uEffjFE5Pa0Q=
+github.com/pegnet/LXRHash v0.0.0-20190729193922-452b32b2d231/go.mod h1:0zBp9GFy9F77zuQbPkAmdUBRiptMaJ1V96eVFdMnXZA=
 github.com/pegnet/OracleRecord v0.0.2/go.mod h1:VrY7Shn4oSCli47CsUYBFjH68IenGYtnLaXaaivepu4=
 github.com/pegnet/pegnet v0.0.2/go.mod h1:FUyEs8fyLOzPXZgyqXcqiOhQi58loNtujykIbxxoKbQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
Updating go mod to point to the new version of lxr hash which changes every hash: https://github.com/pegnet/LXRHash/pull/40