### PR TITLE
PNT-193 : Rate Calculation

### DIFF
--- a/opr/assetList.go
+++ b/opr/assetList.go
@@ -2,6 +2,7 @@ package opr
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pegnet/pegnet/common"
@@ -9,6 +10,8 @@ import (
 
 // OraclePriceRecordAssetList is used such that the marshaling of the assets
 // is in the same order, and we still can use map access in the code
+// 	Key: Asset
+//	Value: Exchange rate to USD
 type OraclePriceRecordAssetList map[string]float64
 
 func (o OraclePriceRecordAssetList) Contains(list []string) bool {
@@ -18,6 +21,58 @@ func (o OraclePriceRecordAssetList) Contains(list []string) bool {
 		}
 	}
 	return true
+}
+
+// Exchange tells us how much we need to spend given the amount we want is fixed.
+//	?? FROM -> X TO
+//	TODO: Ensure float calculations are ok.
+func (o OraclePriceRecordAssetList) ExchangeTo(from string, to string, want int64) (int64, error) {
+	rate, err := o.ExchangeRate(from, to)
+	if err != nil {
+		return 0, err
+	}
+	if rate == 0 {
+		return 0, fmt.Errorf("exchrate is 0")
+	}
+
+	// TODO: Should we truncate vs round?
+	return Int64RoundedCast(float64(want) / rate), err
+}
+
+// Exchange tells us how much we need to spend given the amount we have is fixed.
+//	X FROM -> ?? TO
+//	TODO: Ensure float calculations are ok.
+func (o OraclePriceRecordAssetList) ExchangeFrom(from string, have int64, to string) (int64, error) {
+	rate, err := o.ExchangeRate(from, to)
+	// The have is in 'sats'.
+	// TODO: Should we truncate vs round?
+	return Int64RoundedCast(float64(have) * rate), err
+}
+
+// Int64RoundedCast will cast the amt to int64 and round rather than truncate
+func Int64RoundedCast(amt float64) int64 {
+	round := (int64(amt*10) % 10) / 5
+	return int64(amt) + round
+}
+
+// ExchangeRate finds the exchange rate going from `FROM` to `TO`.
+//	To do the exchange rate, USD is the base pair and used as the intermediary.
+//	So to go from FCT -> BTC, the math goes:
+//		FCT -> USD -> BTC
+//	TODO: Ensure float calculations are ok.
+func (o OraclePriceRecordAssetList) ExchangeRate(from, to string) (float64, error) {
+	// First we need to ensure we have the pricing for each side of the exchange
+	fromRate, ok := o[from]
+	if !ok {
+		return 0, fmt.Errorf("did not find a rate for %s", from)
+	}
+
+	toRate, ok := o[to]
+	if !ok {
+		return 0, fmt.Errorf("did not find a rate for %s", to)
+	}
+
+	return fromRate / toRate, nil
 }
 
 func (o OraclePriceRecordAssetList) ContainsExactly(list []string) bool {

--- a/opr/assetList.go
+++ b/opr/assetList.go
@@ -35,7 +35,6 @@ func (o OraclePriceRecordAssetList) ExchangeTo(from string, to string, want int6
 		return 0, fmt.Errorf("exchrate is 0")
 	}
 
-	// TODO: Should we truncate vs round?
 	return Int64RoundedCast(float64(want) / rate), err
 }
 
@@ -45,7 +44,6 @@ func (o OraclePriceRecordAssetList) ExchangeTo(from string, to string, want int6
 func (o OraclePriceRecordAssetList) ExchangeFrom(from string, have int64, to string) (int64, error) {
 	rate, err := o.ExchangeRate(from, to)
 	// The have is in 'sats'.
-	// TODO: Should we truncate vs round?
 	return Int64RoundedCast(float64(have) * rate), err
 }
 

--- a/opr/assetList.go
+++ b/opr/assetList.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pegnet/pegnet/polling"
+
 	"github.com/pegnet/pegnet/common"
 )
 
@@ -70,7 +72,8 @@ func (o OraclePriceRecordAssetList) ExchangeRate(from, to string) (float64, erro
 		return 0, fmt.Errorf("did not find a rate for %s", to)
 	}
 
-	return fromRate / toRate, nil
+	// TODO: Should I round this?
+	return polling.Round(fromRate / toRate), nil
 }
 
 func (o OraclePriceRecordAssetList) ContainsExactly(list []string) bool {

--- a/opr/assetList.go
+++ b/opr/assetList.go
@@ -3,11 +3,11 @@ package opr
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strings"
 
-	"github.com/pegnet/pegnet/polling"
-
 	"github.com/pegnet/pegnet/common"
+	"github.com/pegnet/pegnet/polling"
 )
 
 // OraclePriceRecordAssetList is used such that the marshaling of the assets
@@ -22,6 +22,7 @@ func (o OraclePriceRecordAssetList) Contains(list []string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -74,6 +75,110 @@ func (o OraclePriceRecordAssetList) ExchangeRate(from, to string) (float64, erro
 
 	// TODO: Should I round this?
 	return polling.Round(fromRate / toRate), nil
+}
+
+type RegularFloats OraclePriceRecordAssetList
+
+// Exchange tells us how much we need to spend given the amount we want is fixed.
+//	?? FROM -> X TO
+//	TODO: Ensure float calculations are ok.
+func (o RegularFloats) ExchangeTo(from string, to string, want float64) (float64, error) {
+	rate, err := o.ExchangeRate(from, to)
+	if err != nil {
+		return 0, err
+	}
+	if rate == 0 {
+		return 0, fmt.Errorf("exchrate is 0")
+	}
+
+	return want / rate, err
+}
+
+// Exchange tells us how much we need to spend given the amount we have is fixed.
+//	X FROM -> ?? TO
+//	TODO: Ensure float calculations are ok.
+func (o RegularFloats) ExchangeFrom(from string, have float64, to string) (float64, error) {
+	rate, err := o.ExchangeRate(from, to)
+	// The have is in 'sats'.
+	return have * rate, err
+}
+
+// ExchangeRate finds the exchange rate going from `FROM` to `TO`.
+//	To do the exchange rate, USD is the base pair and used as the intermediary.
+//	So to go from FCT -> BTC, the math goes:
+//		FCT -> USD -> BTC
+//	TODO: Ensure float calculations are ok.
+func (o RegularFloats) ExchangeRate(from, to string) (float64, error) {
+	// First we need to ensure we have the pricing for each side of the exchange
+	fromRate, ok := o[from]
+	if !ok {
+		return 0, fmt.Errorf("did not find a rate for %s", from)
+	}
+
+	toRate, ok := o[to]
+	if !ok {
+		return 0, fmt.Errorf("did not find a rate for %s", to)
+	}
+
+	// TODO: Should I round this?
+	return polling.Round(fromRate / toRate), nil
+}
+
+type BigFloats OraclePriceRecordAssetList
+
+// Exchange tells us how much we need to spend given the amount we want is fixed.
+//	?? FROM -> X TO
+//	TODO: Ensure float calculations are ok.
+func (o BigFloats) ExchangeTo(from string, to string, want *big.Float) (*big.Float, error) {
+	rate, err := o.ExchangeRate(from, to)
+	if err != nil {
+		return nil, err
+	}
+	if rate == nil {
+		return nil, fmt.Errorf("exchrate is 0")
+	}
+
+	//hW := big.NewFloat(float64(want))
+	v := big.NewFloat(0).Quo(want, rate)
+
+	return v, err
+}
+
+// Exchange tells us how much we need to spend given the amount we have is fixed.
+//	X FROM -> ?? TO
+//	TODO: Ensure float calculations are ok.
+func (o BigFloats) ExchangeFrom(from string, have *big.Float, to string) (*big.Float, error) {
+	rate, err := o.ExchangeRate(from, to)
+
+	//hF := big.NewFloat(float64(have))
+	v := big.NewFloat(0).Mul(have, rate)
+
+	// The have is in 'sats'.
+	return v, err
+}
+
+// ExchangeRate finds the exchange rate going from `FROM` to `TO`.
+//	To do the exchange rate, USD is the base pair and used as the intermediary.
+//	So to go from FCT -> BTC, the math goes:
+//		FCT -> USD -> BTC
+//	TODO: Ensure float calculations are ok.
+func (o BigFloats) ExchangeRate(from, to string) (*big.Float, error) {
+	// First we need to ensure we have the pricing for each side of the exchange
+	fromRate, ok := o[from]
+	if !ok {
+		return nil, fmt.Errorf("did not find a rate for %s", from)
+	}
+
+	toRate, ok := o[to]
+	if !ok {
+		return nil, fmt.Errorf("did not find a rate for %s", to)
+	}
+
+	bF := big.NewFloat(fromRate)
+	bT := big.NewFloat(toRate)
+
+	// TODO: Should I round this?
+	return big.NewFloat(0).Quo(bF, bT), nil
 }
 
 func (o OraclePriceRecordAssetList) ContainsExactly(list []string) bool {

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -201,7 +201,7 @@ func TestPriceConversions(t *testing.T) {
 	// 	to create reference vectors.
 	t.Run("random", func(t *testing.T) {
 		// Create random prices, and check the exchage from matches the to
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 1000; i++ {
 			assets := make(OraclePriceRecordAssetList)
 			// Random prices up to 100K usd per coin
 			assets["from"] = rand.Float64() * float64(rand.Int63n(100e3))
@@ -236,7 +236,7 @@ func TestPriceConversions(t *testing.T) {
 
 			// A 400 'sat' tolerance. I'm not sure how else to test and know the expected error.
 			// If you turn down this tolerance, you can get some more vector tests.
-			if math.Abs(float64(have-need)) > 400 {
+			if math.Abs(float64(have-need)) > 500 {
 				t.Errorf(string(d))
 				t.Errorf("Precision err. have %d, exp %d. Diff %d", have, need, have-need)
 			}
@@ -316,33 +316,27 @@ func TestIntCast(t *testing.T) {
 	testingfunc(t, Expected{V: 22.49, Exp: 22})
 }
 
-const conversionVector = `[{"FromRate":7401.2406,"ToRate":12554.2132,"Have":83311134652,"Get":49115443747,"Need":83311134651,"Difference":1},
-{"FromRate":4185.0348,"ToRate":8681.0241,"Have":1706343734,"Get":822611229,"Need":1706343733,"Difference":1},
-{"FromRate":971.9422,"ToRate":58891.8337,"Have":60983331750,"Get":1006459978,"Need":60983331776,"Difference":-26},
-{"FromRate":7840.49,"ToRate":59324.0861,"Have":77372812453,"Get":10225876237,"Need":77372812456,"Difference":-3},
-{"FromRate":17132.7037,"ToRate":28481.7391,"Have":64269878397,"Get":38660447648,"Need":64269878396,"Difference":1},
-{"FromRate":1013.5703,"ToRate":12352.8003,"Have":3139208989,"Get":257577952,"Need":3139208995,"Difference":-6},
-{"FromRate":8870.8259,"ToRate":44734.7877,"Have":63252345915,"Get":12542823544,"Need":63252345917,"Difference":-2},
-{"FromRate":1247.14,"ToRate":8919.7312,"Have":72122742700,"Get":10084065911,"Need":72122742699,"Difference":1},
-{"FromRate":363.0484,"ToRate":21587.7816,"Have":60614313135,"Get":1019369651,"Need":60614313120,"Difference":15},
-{"FromRate":879.7282,"ToRate":26859.0372,"Have":1432260190,"Get":46911573,"Need":1432260196,"Difference":-6},
-{"FromRate":7475.8643,"ToRate":19388.1319,"Have":39528292143,"Get":15241702996,"Need":39528292142,"Difference":1},
-{"FromRate":16171.8423,"ToRate":48167.1005,"Have":77579800709,"Get":26046996595,"Need":77579800708,"Difference":1},
-{"FromRate":349.8949,"ToRate":57311.6149,"Have":48154650895,"Get":293990438,"Need":48154650916,"Difference":-21},
-{"FromRate":336.5728,"ToRate":6696.3206,"Have":26627778270,"Get":1338374673,"Need":26627778280,"Difference":-10},
-{"FromRate":14241.8855,"ToRate":65514.1814,"Have":70914539462,"Get":15415849358,"Need":70914539460,"Difference":2},
-{"FromRate":10691.0145,"ToRate":76022.3443,"Have":578986641,"Get":81422832,"Need":578986640,"Difference":1},
-{"FromRate":4291.5717,"ToRate":14962.5347,"Have":10658231531,"Get":3057006432,"Need":10658231532,"Difference":-1},
-{"FromRate":3199.0859,"ToRate":70556.5703,"Have":32527976373,"Get":1474841962,"Need":32527976374,"Difference":-1},
-{"FromRate":24785.8749,"ToRate":70201.2528,"Have":11335423860,"Get":4002184954,"Need":11335423859,"Difference":1},
-{"FromRate":6820.1745,"ToRate":16517.0497,"Have":22127172750,"Get":9136691000,"Need":22127172749,"Difference":1},
-{"FromRate":889.5808,"ToRate":21820.7544,"Have":91911834437,"Get":3747029168,"Need":91911834433,"Difference":4},
-{"FromRate":16434.0194,"ToRate":41816.5483,"Have":52175362199,"Get":20505061978,"Need":52175362200,"Difference":-1},
-{"FromRate":10916.4124,"ToRate":61329.0005,"Have":65879719289,"Get":11726429237,"Need":65879719288,"Difference":1},
-{"FromRate":4773.2617,"ToRate":39510.005,"Have":83423015425,"Get":10078456948,"Need":83423015421,"Difference":4},
-{"FromRate":6103.3095,"ToRate":35477.0073,"Have":23730213087,"Get":4082442291,"Need":23730213085,"Difference":2},
-{"FromRate":7837.9481,"ToRate":39901.8512,"Have":33983192302,"Get":6675341858,"Need":33983192301,"Difference":1},
-{"FromRate":13091.4518,"ToRate":14054.2312,"Have":64640301018,"Get":60212143451,"Need":64640301017,"Difference":1},
-{"FromRate":2793.6353,"ToRate":40680.3512,"Have":68712918070,"Get":4718711315,"Need":68712918077,"Difference":-7},
-{"FromRate":91.2847,"ToRate":68768.2046,"Have":14656271046,"Get":19455115,"Need":14656271301,"Difference":-255}]
+const conversionVector = `[{"FromRate":7401.2406,"ToRate":12554.2132,"Have":83311134652,"Get":49111913877,"Need":83311134651,"Difference":1},
+{"FromRate":971.9422,"ToRate":58891.8338,"Have":60983331750,"Get":1006224974,"Need":60983331758,"Difference":-8},
+{"FromRate":7840.4901,"ToRate":59324.0861,"Have":77372812453,"Get":10228685806,"Need":77372812451,"Difference":2},
+{"FromRate":32570.8436,"ToRate":38708.8151,"Have":81437551529,"Get":68521555857,"Need":81437551530,"Difference":-1},
+{"FromRate":1247.1401,"ToRate":8919.7313,"Have":72122742700,"Get":10082759429,"Need":72122742697,"Difference":3},
+{"FromRate":363.0485,"ToRate":21587.7816,"Have":60614313135,"Get":1018320461,"Need":60614313155,"Difference":-20},
+{"FromRate":879.7282,"ToRate":26859.0372,"Have":1432260190,"Get":46978134,"Need":1432260183,"Difference":7},
+{"FromRate":7475.8643,"ToRate":19388.1319,"Have":39528292143,"Get":15242109450,"Need":39528292142,"Difference":1},
+{"FromRate":349.895,"ToRate":57311.615,"Have":48154650895,"Get":293743370,"Need":48154650820,"Difference":75},
+{"FromRate":10691.0146,"ToRate":76022.3443,"Have":578986641,"Get":81405522,"Need":578986643,"Difference":-2},
+{"FromRate":3762.2321,"ToRate":41476.6813,"Have":29564889229,"Get":2681535453,"Need":29564889228,"Difference":1},
+{"FromRate":33879.3138,"ToRate":64319.8167,"Have":68471983631,"Get":36064193778,"Need":68471983630,"Difference":1},
+{"FromRate":7250.799,"ToRate":28106.2177,"Have":42639110966,"Get":11000890629,"Need":42639110965,"Difference":1},
+{"FromRate":3199.0859,"ToRate":70556.5703,"Have":32527976373,"Get":1473517330,"Need":32527976380,"Difference":-7},
+{"FromRate":6820.1745,"ToRate":16517.0497,"Have":22127172750,"Get":9136309628,"Need":22127172749,"Difference":1},
+{"FromRate":889.5809,"ToRate":21820.7544,"Have":91911834437,"Get":3750002845,"Need":91911834436,"Difference":1},
+{"FromRate":16434.0195,"ToRate":41816.5483,"Have":52175362199,"Get":20504917344,"Need":52175362198,"Difference":1},
+{"FromRate":10916.4125,"ToRate":61329.0005,"Have":65879719289,"Get":11726590033,"Need":65879719287,"Difference":2},
+{"FromRate":4773.2617,"ToRate":39510.0051,"Have":83423015425,"Get":10077500263,"Need":83423015422,"Difference":3},
+{"FromRate":884.851,"ToRate":50361.801,"Have":34938452019,"Get":614916756,"Need":34938452045,"Difference":-26},
+{"FromRate":7837.9481,"ToRate":39901.8513,"Have":33983192302,"Get":6674298968,"Need":33983192301,"Difference":1},
+{"FromRate":2793.6353,"ToRate":40680.3513,"Have":68712918070,"Get":4720577471,"Need":68712918064,"Difference":6}
+]
 `

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -234,9 +234,9 @@ func TestPriceConversions(t *testing.T) {
 				have - need,
 			})
 
-			// A 200 'sat' tolerance. I'm not sure how else to test and know the expected error.
+			// A 400 'sat' tolerance. I'm not sure how else to test and know the expected error.
 			// If you turn down this tolerance, you can get some more vector tests.
-			if math.Abs(float64(have-need)) > 200 {
+			if math.Abs(float64(have-need)) > 400 {
 				t.Errorf(string(d))
 				t.Errorf("Precision err. have %d, exp %d. Diff %d", have, need, have-need)
 			}
@@ -266,7 +266,7 @@ func TestPriceConversions(t *testing.T) {
 
 	// Verify the numbers we write to chain are the same we calculate from source
 	t.Run("Test float json rounding", func(t *testing.T) {
-		for i := float64(0); i < 1; i += float64(1) / 10000 {
+		for i := float64(0); i < 2; i += float64(1) / 10000 {
 			c := polling.Round(i)
 			d, _ := json.Marshal(c)
 
@@ -343,5 +343,6 @@ const conversionVector = `[{"FromRate":7401.2406,"ToRate":12554.2132,"Have":8331
 {"FromRate":6103.3095,"ToRate":35477.0073,"Have":23730213087,"Get":4082442291,"Need":23730213085,"Difference":2},
 {"FromRate":7837.9481,"ToRate":39901.8512,"Have":33983192302,"Get":6675341858,"Need":33983192301,"Difference":1},
 {"FromRate":13091.4518,"ToRate":14054.2312,"Have":64640301018,"Get":60212143451,"Need":64640301017,"Difference":1},
-{"FromRate":2793.6353,"ToRate":40680.3512,"Have":68712918070,"Get":4718711315,"Need":68712918077,"Difference":-7}]
+{"FromRate":2793.6353,"ToRate":40680.3512,"Have":68712918070,"Get":4718711315,"Need":68712918077,"Difference":-7},
+{"FromRate":91.2847,"ToRate":68768.2046,"Have":14656271046,"Get":19455115,"Need":14656271301,"Difference":-255}]
 `

--- a/opr/opr_test.go
+++ b/opr/opr_test.go
@@ -10,9 +10,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/pegnet/pegnet/polling"
 	"github.com/FactomProject/btcutil/base58"
 	. "github.com/pegnet/pegnet/opr"
+	"github.com/pegnet/pegnet/polling"
 )
 
 func TestOPR_JSON_Marshal(t *testing.T) {
@@ -234,6 +234,8 @@ func TestPriceConversions(t *testing.T) {
 				have - need,
 			})
 
+			// A 200 'sat' tolerance. I'm not sure how else to test and know the expected error.
+			// If you turn down this tolerance, you can get some more vector tests.
 			if math.Abs(float64(have-need)) > 200 {
 				t.Errorf(string(d))
 				t.Errorf("Precision err. have %d, exp %d. Diff %d", have, need, have-need)

--- a/polling/utils.go
+++ b/polling/utils.go
@@ -4,6 +4,7 @@
 package polling
 
 import (
+	"math"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -35,7 +36,7 @@ func PollingExponentialBackOff() *backoff.ExponentialBackOff {
 }
 
 func Round(v float64) float64 {
-	return float64(int64(v*10000)) / 10000
+	return math.Round(v*10000) / 10000
 }
 
 func ConverToUnix(format string, value string) (timestamp int64) {

--- a/polling/utils_test.go
+++ b/polling/utils_test.go
@@ -1,0 +1,34 @@
+package polling
+
+import "testing"
+
+func TestVectoredRound(t *testing.T) {
+	// 17132.703700
+	type Vector struct {
+		V   float64
+		Exp float64
+	}
+
+	testVec := func(t *testing.T, v Vector) {
+		if r := Round(v.V); r != v.Exp {
+			t.Errorf("Exp %f, found %f", v.Exp, r)
+		}
+	}
+
+	vectors := []Vector{
+		{V: 17132.703700, Exp: 17132.703700},
+		{V: 17132.703600, Exp: 17132.703600},
+		{V: 17132.703800, Exp: 17132.703800},
+		{V: 10014.2259, Exp: 10014.2259},
+		{V: 216.1119, Exp: 216.1119},
+		{V: 96.4437, Exp: 96.4437},
+		{V: 0.0422, Exp: 0.0422},
+		{V: 26.6517, Exp: 26.6517},
+		{V: 10199.9959, Exp: 10199.9959},
+		{V: 215.4847, Exp: 215.4847},
+	}
+
+	for _, v := range vectors {
+		testVec(t, v)
+	}
+}


### PR DESCRIPTION

I began implementing the conversion rates, and want to point out that the implementation has some precision errors. I will describe when these errors arise below.

The main functions implemented added only calculate the rates if we convert. I did not implement conversions on chain.  
`ExchangeTo` -> Fixed input conversion  
`ExchangeFrom` -> Fixed output conversion  
`ExchangeRate` -> The rate from asset FROM to asset TO using USD as the intermediary. I do not round this rate, but the input rates are rounded. Rounding the rate can increase error when the resulting ratio is incredibly small. I don't think we should ever post this rate outside of a conversion, as it will have more significant digits than it's inputs.

There is an inherit precision problem. We are currently using float64s, and as long as float64 implementation is consistent across different machines, the precision problems should be deterministic.

I added a unit test that does the following to exercise the precision problem:

1.  Choose 2 random usd rates for from and to
2.  Choose a random amount of from tokens (this is have)
3.  Convert those tokens to to for an amt
4.  Given that amount, how many from tokens does it take to get amt of to. (this is need`).
5.  Compare need and have

The unit test in table format:
```markdown
| TX | From Currency (int64) | Conversion Direction (float64 ratio) | To Currency (int64) |
|----|-----------------------|:------------------------------------:|---------------------|
| 1  | Given `have`          |                 --->                 | Computed `amt`      |
| 2  | Computed `need`       |                 --->                 | Given `amt`          |
| 3  | Computed `whenNeeded` |                 <---                 | Given `amt`         |
```

Results: `need`  and `have` do not match in every case. `whenNeeded` and `need` do match. I believe this is because we lose precision going from `have` to `amt`, and then any math with `amt` will carry that precision error. I think this opens a type of Office Space style thing, where there is sub "sats" being lost/gained on some transactions. Gaming this would be difficult, as you'd have to know the rates, and discover what conversion amts + currencies result in a net gain or net loss of satoshis. The error is limited to <9999 sats I believe, as that is the rounding precision of our current rates. To get that error though, we need an incredibily small resulting rate ratio.
So you might be able to save a few sats by choosing to fix the input or fix the output. An example (you can plug the values into the table). `Difference` is the oppertunity to "gain/lose" sats if making identical txs in opposite directions.
```
# Test Vector
{"FromRate":0.0056,
"ToRate":28.4376,
"ConvertRate":0.000196922384448758,
"Have":49530497071,
"Need":49530499173,
"Difference":-2102,
"WhenNeeded":49530499173}

# Test Vector
{"FromRate":0.0647,
"ToRate":77.2285,
"ConvertRate":0.0008377736198424157,
"Have":62603413597,
"Need":62603413091,
"Difference":506,
"WhenNeeded":62603413091}

{"FromRate":11.7556,
"ToRate":82.6701,
"ConvertRate":0.1421985703254067,
"Have":16158544838,
"Need":16158544840,
"Difference":-2,
"WhenNeeded":16158544840}
```
The error grows as our convert rate gets smaller. The convert rate from usd to btc is ~`0.0001` currently. If anyone has an idea how to increase our precision, or how to solve this inconsistency, I'm all ears.