### PR TITLE
If the object is nil, we send a nil to the client. 

### DIFF
--- a/networkMiner/server.go
+++ b/networkMiner/server.go
@@ -171,7 +171,11 @@ func (c *MiningServer) ForwardMonitorEvents() {
 
 			m := new(NetworkMessage)
 			m.NetworkCommand = ConstructedOPR
-			m.Data = *oprobject
+			if oprobject == nil {
+				m.Data = nil
+			} else {
+				m.Data = *oprobject
+			}
 
 			c.clientsLock.Lock()
 			for _, c := range c.clients {


### PR DESCRIPTION
The client can handle a nil as an error