### PR TITLE
Grader refactor

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -4,8 +4,6 @@
 package api
 
 import (
-	"bytes"
-	"encoding/hex"
 	"strconv"
 
 	"github.com/FactomProject/factom"
@@ -15,7 +13,7 @@ import (
 // -------------------------------------------------------------
 // Required for M1
 
-func getPerformance(params interface{}) (*PerformanceResult, *Error) {
+func (a *APIServer) getPerformance(params interface{}) (*PerformanceResult, *Error) {
 	performanceParams := new(PerformanceParameters)
 	err := MapToObject(params, performanceParams)
 	if err != nil {
@@ -72,7 +70,7 @@ func getPerformance(params interface{}) (*PerformanceResult, *Error) {
 		gradingPlacements[i] = 0
 	}
 	for i := start; i <= end; i++ {
-		block := oprBlockByHeight(i)
+		block := a.Grader.OprBlockByHeight(i)
 		if block == nil {
 			continue
 		}
@@ -134,14 +132,14 @@ func getPerformance(params interface{}) (*PerformanceResult, *Error) {
 // -------------------------------------------------------------
 // Somewhat temporary, might not remain
 
-func getCurrentOPRs() (*GenericResult, *Error) {
+func (a *APIServer) getCurrentOPRs() (*GenericResult, *Error) {
 	height := getLeaderHeight()
-	records := oprBlockByHeight(height)
+	records := a.Grader.OprBlockByHeight(height)
 	return &GenericResult{OPRBlock: records}, nil
 }
 
 // getOprByHash handler to return the opr by full hash
-func getOprByHash(params interface{}) (*GenericResult, *Error) {
+func (a *APIServer) getOprByHash(params interface{}) (*GenericResult, *Error) {
 	genericParams := new(GenericParameters)
 	err := MapToObject(params, genericParams)
 	if err != nil {
@@ -149,12 +147,12 @@ func getOprByHash(params interface{}) (*GenericResult, *Error) {
 	} else if genericParams.Hash == "" {
 		return nil, NewInvalidParametersError()
 	}
-	record := oprByHash(genericParams.Hash)
+	record := a.Grader.OprByHash(genericParams.Hash)
 	return &GenericResult{OPR: &record}, nil
 }
 
 // getOprByShortHash handler to return the opr by the short 8 byte hash
-func getOprByShortHash(params interface{}) (*GenericResult, *Error) {
+func (a *APIServer) getOprByShortHash(params interface{}) (*GenericResult, *Error) {
 	genericParams := new(GenericParameters)
 	err := MapToObject(params, genericParams)
 	if err != nil {
@@ -162,12 +160,12 @@ func getOprByShortHash(params interface{}) (*GenericResult, *Error) {
 	} else if genericParams.Hash == "" {
 		return nil, NewInvalidParametersError()
 	}
-	record := oprByShortHash(genericParams.Hash)
+	record := a.Grader.OprByShortHash(genericParams.Hash)
 	return &GenericResult{OPR: &record}, nil
 }
 
 // getOprsByDigitalID handler to return all oprs based on Digital ID
-func getOprsByDigitalID(params interface{}) (*GenericResult, *Error) {
+func (a *APIServer) getOprsByDigitalID(params interface{}) (*GenericResult, *Error) {
 	genericParams := new(GenericParameters)
 	err := MapToObject(params, genericParams)
 	if err != nil {
@@ -175,13 +173,13 @@ func getOprsByDigitalID(params interface{}) (*GenericResult, *Error) {
 	} else if genericParams.DigitalID == "" {
 		return nil, NewInvalidParametersError()
 	}
-	records := oprsByDigitalID(genericParams.DigitalID)
+	records := a.Grader.OprsByDigitalID(genericParams.DigitalID)
 	return &GenericResult{OPRs: records}, nil
 }
 
 // getOPRsByHeight handler will return all OPR's at any height except the current block.
 // Will only return local OPR's for the current chainhead.
-func getOPRsByHeight(params interface{}) (*GenericResult, *Error) {
+func (a *APIServer) getOPRsByHeight(params interface{}) (*GenericResult, *Error) {
 	genericParams := new(GenericParameters)
 	err := MapToObject(params, genericParams)
 	if err != nil {
@@ -189,7 +187,7 @@ func getOPRsByHeight(params interface{}) (*GenericResult, *Error) {
 	} else if genericParams.Height == nil {
 		return nil, NewInvalidParametersError()
 	}
-	oprBlock := oprBlockByHeight(*genericParams.Height)
+	oprBlock := a.Grader.OprBlockByHeight(*genericParams.Height)
 	return &GenericResult{OPRBlock: oprBlock}, nil
 }
 
@@ -210,16 +208,16 @@ func getBalance(params interface{}) (*GenericResult, *Error) {
 // Helpers
 
 // getWinners returns the current 10 winners entry shorthashes from the last recorded block
-func getWinners() [10]string {
+func (a *APIServer) getWinners() [10]string {
 	height := getLeaderHeight()
-	currentOPRS := oprBlockByHeight(height)
+	currentOPRS := a.Grader.OprBlockByHeight(height)
 	record := currentOPRS.OPRs[0]
 	return record.WinPreviousOPR
 }
 
 // getWinner returns the highest graded entry shorthash from the last recorded block
-func getWinner() string {
-	return getWinners()[0]
+func (a *APIServer) getWinner() string {
+	return a.getWinners()[0]
 }
 
 // getLeaderHeight helper function, cleaner than using the factom monitor
@@ -229,55 +227,4 @@ func getLeaderHeight() int64 {
 		return 0
 	}
 	return heights.LeaderHeight
-}
-
-// oprBlockByHeight returns a single OPRBlock
-func oprBlockByHeight(dbht int64) *opr.OprBlock {
-	for _, block := range opr.OPRBlocks {
-		if block.Dbht == dbht {
-			return block
-		}
-	}
-	return nil
-}
-
-// oprsByDigitalID returns every OPR created by a given ID
-// Multiple ID's per miner or single daemon are possible.
-// This function searches through every possible ID and returns all.
-func oprsByDigitalID(did string) []opr.OraclePriceRecord {
-	var subset []opr.OraclePriceRecord
-	for _, block := range opr.OPRBlocks {
-		for _, record := range block.OPRs {
-			if record.FactomDigitalID == did {
-				subset = append(subset, *record)
-			}
-		}
-	}
-	return subset
-}
-
-// oprByHash returns the entire OPR based on it's hash
-func oprByHash(hash string) opr.OraclePriceRecord {
-	for _, block := range opr.OPRBlocks {
-		for _, record := range block.OPRs {
-			if hash == hex.EncodeToString(record.OPRHash) {
-				return *record
-			}
-		}
-	}
-	return opr.OraclePriceRecord{}
-}
-
-// Failing tests. Need to grok how the short 8 byte winning oprhashes are done.
-func oprByShortHash(shorthash string) opr.OraclePriceRecord {
-	hashBytes, _ := hex.DecodeString(shorthash)
-	// hashbytes = reverseBytes(hashbytes)
-	for _, block := range opr.OPRBlocks {
-		for _, record := range block.OPRs {
-			if bytes.Compare(hashBytes, record.OPRHash[:8]) == 0 {
-				return *record
-			}
-		}
-	}
-	return opr.OraclePriceRecord{}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -395,7 +395,7 @@ var networkCoordinator = &cobra.Command{
 		monitor := LaunchFactomMonitor(Config)
 		grader := LaunchGrader(Config, monitor, ctx)
 		statTracker := LaunchStatistics(Config, ctx)
-		apiserver := LaunchAPI(Config, statTracker)
+		apiserver := LaunchAPI(Config, statTracker, grader)
 		LaunchControlPanel(Config, ctx, monitor, statTracker)
 		var _ = apiserver
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -297,52 +296,14 @@ var grader = &cobra.Command{
 
 		q := LaunchGrader(Config, monitor, context.Background())
 
+		alert := q.GetAlert("cmd")
+
 		for {
-			time.Sleep(3 * time.Second)
-		}
-
-		for _, block := range q.GetBlocks() {
-			winners := block.GradedOPRs[:10]
-			str := ""
-			for _, win := range winners {
-				str += string(win.EntryHash)
+			select {
+			case a := <-alert:
+				fmt.Println(a)
 			}
-			fmt.Printf("%d %x\n", block.Dbht, sha256.Sum256([]byte(str)))
 		}
-
-		//news := q.GetBlocks()
-		//if len(news) != len(opr.OPRBlocks) {
-		//	panic("diff lengths")
-		//}
-		//for i, orig := range opr.OPRBlocks {
-		//	new := news[i]
-		//	oWinners := orig.GradedOPRs[:10]
-		//	nWinners := new.GradedOPRs[:10]
-		//
-		//	for i := range oWinners {
-		//		if bytes.Compare(oWinners[i].EntryHash, nWinners[i].EntryHash) != 0 {
-		//			panic("winners are different")
-		//		}
-		//
-		//		if oWinners[i].Grade != nWinners[i].Grade {
-		//			panic("grades are different")
-		//		}
-		//	}
-		//}
-
-		//fmt.Println(len(news), len(opr.OPRBlocks))
-
-		//grader := opr.NewGrader()
-		//go grader.Run(Config, monitor)
-		//
-		//alert := grader.GetAlert("cmd")
-		//
-		//for {
-		//	select {
-		//	case a := <-alert:
-		//		fmt.Println(a)
-		//	}
-		//}
 	},
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -282,6 +282,7 @@ var datasources = &cobra.Command{
 var grader = &cobra.Command{
 	Use: "grader ",
 	Run: func(cmd *cobra.Command, args []string) {
+		opr.InitLX()
 		ValidateConfig(Config) // Will fatal log if it fails
 
 		monitor := common.GetMonitor()
@@ -292,18 +293,53 @@ var grader = &cobra.Command{
 			err := <-errListener
 			panic("Monitor threw error: " + err.Error())
 		}()
+		var err error
 
-		grader := opr.NewGrader()
-		go grader.Run(Config, monitor)
+		//err = opr.GetEntryBlocks(Config)
+		//if err != nil {
+		//	panic(err)
+		//}
+		//fmt.Println()
 
-		alert := grader.GetAlert("cmd")
-
-		for {
-			select {
-			case a := <-alert:
-				fmt.Println(a)
-			}
+		q := opr.NewQuickGrader(Config)
+		err = q.Sync()
+		if err != nil {
+			panic(err)
 		}
+
+		//news := q.GetBlocks()
+		//if len(news) != len(opr.OPRBlocks) {
+		//	panic("diff lengths")
+		//}
+		//for i, orig := range opr.OPRBlocks {
+		//	new := news[i]
+		//	oWinners := orig.GradedOPRs[:10]
+		//	nWinners := new.GradedOPRs[:10]
+		//
+		//	for i := range oWinners {
+		//		if bytes.Compare(oWinners[i].EntryHash, nWinners[i].EntryHash) != 0 {
+		//			panic("winners are different")
+		//		}
+		//
+		//		if oWinners[i].Grade != nWinners[i].Grade {
+		//			panic("grades are different")
+		//		}
+		//	}
+		//}
+
+		//fmt.Println(len(news), len(opr.OPRBlocks))
+
+		//grader := opr.NewGrader()
+		//go grader.Run(Config, monitor)
+		//
+		//alert := grader.GetAlert("cmd")
+		//
+		//for {
+		//	select {
+		//	case a := <-alert:
+		//		fmt.Println(a)
+		//	}
+		//}
 	},
 }
 
@@ -357,7 +393,7 @@ var networkCoordinator = &cobra.Command{
 
 		// Services
 		monitor := LaunchFactomMonitor(Config)
-		grader := LaunchGrader(Config, monitor)
+		grader := LaunchGrader(Config, monitor, ctx)
 		statTracker := LaunchStatistics(Config, ctx)
 		apiserver := LaunchAPI(Config, statTracker)
 		LaunchControlPanel(Config, ctx, monitor, statTracker)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pegnet/pegnet/database"
-
 	"github.com/FactomProject/factom"
 	"github.com/pegnet/pegnet/api"
 	"github.com/pegnet/pegnet/common"
@@ -296,23 +294,11 @@ var grader = &cobra.Command{
 			err := <-errListener
 			panic("Monitor threw error: " + err.Error())
 		}()
-		var err error
 
-		//err = opr.GetEntryBlocks(Config)
-		//if err != nil {
-		//	panic(err)
-		//}
-		//fmt.Println()
+		q := LaunchGrader(Config, monitor, context.Background())
 
-		ldb := new(database.Ldb)
-		err = ldb.Open("tmp")
-		if err != nil {
-			panic(err)
-		}
-		q := opr.NewQuickGrader(Config, ldb)
-		err = q.Sync()
-		if err != nil {
-			panic(err)
+		for {
+			time.Sleep(3 * time.Second)
 		}
 
 		for _, block := range q.GetBlocks() {

--- a/cmd/cmdProvider.go
+++ b/cmd/cmdProvider.go
@@ -55,5 +55,15 @@ func (c *CmdFlagProvider) Load() (map[string]string, error) {
 		}
 	}
 
+	dbtype, _ := c.cmd.Flags().GetString("mienrdbtype")
+	if dbtype != "" {
+		settings[common.ConfigMinerDBType] = dbtype
+	}
+
+	dbpath, _ := c.cmd.Flags().GetString("mienrdb")
+	if dbtype != "" {
+		settings[common.ConfigMinerDBPath] = dbpath
+	}
+
 	return settings, nil
 }

--- a/cmd/cmdProvider.go
+++ b/cmd/cmdProvider.go
@@ -61,7 +61,7 @@ func (c *CmdFlagProvider) Load() (map[string]string, error) {
 	}
 
 	dbpath, _ := c.cmd.Flags().GetString("mienrdb")
-	if dbtype != "" {
+	if dbpath != "" {
 		settings[common.ConfigMinerDBPath] = dbpath
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/FactomProject/factom"
@@ -106,10 +105,10 @@ func ValidateConfig(config *config.Config) {
 		log.WithError(err).Fatal("failed to read the identity chain or miner id")
 	}
 
-	valid, _ := regexp.MatchString("^[a-zA-Z0-9,]+$", identity)
-	if !valid {
-		log.WithError(err).Fatal("only alphanumeric characters and commas are allowed in the identity")
+	if err := common.ValidIdentity(identity); err != nil {
+		log.WithError(err).Fatal("invalid identity")
 	}
+
 }
 
 func initLogger() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,7 @@ var rootCmd = &cobra.Command{
 
 		// Services
 		monitor := LaunchFactomMonitor(Config)
-		grader := LaunchGrader(Config, monitor)
+		grader := LaunchGrader(Config, monitor, ctx)
 		statTracker := LaunchStatistics(Config, ctx)
 		apiserver := LaunchAPI(Config, statTracker)
 		LaunchControlPanel(Config, ctx, monitor, statTracker)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ var rootCmd = &cobra.Command{
 		monitor := LaunchFactomMonitor(Config)
 		grader := LaunchGrader(Config, monitor, ctx)
 		statTracker := LaunchStatistics(Config, ctx)
-		apiserver := LaunchAPI(Config, statTracker)
+		apiserver := LaunchAPI(Config, statTracker, grader)
 		LaunchControlPanel(Config, ctx, monitor, statTracker)
 		var _ = apiserver
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,7 +141,9 @@ func rootPreRunSetup(cmd *cobra.Command, args []string) error {
 		log.WithError(err).Fatal("Failed to read current user's name")
 	}
 
-	// Set the PegnetHome for pegnet files
+	// Set the PegnetHome for pegnet files.
+	// This is so we know where to place all the pegnet files. We can then use
+	// the $PEGNETHOME in place of ~/.pegnet and be able to change it in only 1 spot.
 	pegnethome := os.Getenv("PEGNETHOME")
 	if pegnethome == "" {
 		var _ = os.Setenv("PEGNETHOME", filepath.Join(u.HomeDir, ".pegnet"))

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/pegnet/pegnet/database"
+
 	"github.com/pegnet/pegnet/api"
 	"github.com/pegnet/pegnet/common"
 	"github.com/pegnet/pegnet/controlPanel"
@@ -26,7 +28,7 @@ func LaunchFactomMonitor(config *config.Config) *common.Monitor {
 }
 
 func LaunchGrader(config *config.Config, monitor *common.Monitor, ctx context.Context) *opr.QuickGrader {
-	grader := opr.NewQuickGrader(config)
+	grader := opr.NewQuickGrader(config, database.NewMapDb())
 	go grader.Run(monitor, ctx)
 	return grader
 }

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -38,8 +38,8 @@ func LaunchStatistics(config *config.Config, ctx context.Context) *mining.Global
 	return statTracker
 }
 
-func LaunchAPI(config *config.Config, stats *mining.GlobalStatTracker) *api.APIServer {
-	s := api.NewApiServer()
+func LaunchAPI(config *config.Config, stats *mining.GlobalStatTracker, grader *opr.QuickGrader) *api.APIServer {
+	s := api.NewApiServer(grader)
 
 	go s.Listen(8099) // TODO: Do not hardcode this
 	return s

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -55,6 +55,9 @@ func LaunchGrader(config *config.Config, monitor *common.Monitor, ctx context.Co
 			os.Exit(1)
 		}
 		db = ldb
+	default:
+		log.Fatalf("%s is not a valid db type", dbtype)
+		os.Exit(1)
 	}
 
 	grader := opr.NewQuickGrader(config, db)

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -25,9 +25,9 @@ func LaunchFactomMonitor(config *config.Config) *common.Monitor {
 	return monitor
 }
 
-func LaunchGrader(config *config.Config, monitor *common.Monitor) *opr.Grader {
-	grader := opr.NewGrader()
-	go grader.Run(config, monitor)
+func LaunchGrader(config *config.Config, monitor *common.Monitor, ctx context.Context) *opr.QuickGrader {
+	grader := opr.NewQuickGrader(config)
+	go grader.Run(monitor, ctx)
 	return grader
 }
 

--- a/common/common.go
+++ b/common/common.go
@@ -35,6 +35,10 @@ func GetNetwork(network string) (string, error) {
 }
 
 const (
+	ZeroHash = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+const (
 	MainNetwork = "MainNet"
 	TestNetwork = "TestNet-pM1"
 

--- a/common/config.go
+++ b/common/config.go
@@ -16,6 +16,8 @@ const (
 	ConfigCoordinatorSecret            = "Miner.CoordinatorSecret"
 	ConfigCoordinatorUseAuthentication = "Miner.UseCoordinatorAuthentication"
 	ConfigSubmissionCutOff             = "Miner.SubmissionCutOff"
+	ConfigMinerDBPath                  = "Database.MinerDatabase"
+	ConfigMinerDBType                  = "Database.MinerDatabaseType"
 
 	ConfigCoinbaseAddress = "Miner.CoinbaseAddress"
 	ConfigPegnetNetwork   = "Miner.Network"

--- a/common/utils.go
+++ b/common/utils.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -49,6 +50,14 @@ func PullValue(line string, howMany int) string {
 	line = line[0:pos]
 	//fmt.Println(line)
 	return line
+}
+
+func ValidIdentity(identity string) error {
+	valid, _ := regexp.MatchString("^[a-zA-Z0-9,]+$", identity)
+	if !valid {
+		return fmt.Errorf("only alphanumeric characters and commas are allowed in the identity")
+	}
+	return nil
 }
 
 // CheckPrefix()

--- a/database/idatabase.go
+++ b/database/idatabase.go
@@ -3,15 +3,28 @@
 
 package database
 
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+)
+
 type Bucket int
 
 const (
-	INVALID           Bucket = iota // Don't use zero, that's a good invalid value
-	BUCKET_OPR                      // Mostly Valid (has the prior winners, has proper structure
-	BUCKET_ALL_EB                   // OPR chain Entry Blocks indexed by Directory Block Height
-	BUCKET_VALID_EB                 // OPR chain Entry Blocks that actually qualify to pay out mining fees and set asset prices
-	BUCKET_VALID_OPRS               // OPR Lists of valid OPRS, indexed by Directory Block Height, ordered as graded
-	BUCKET_BALANCES                 // PNT payout balances
+	INVALID Bucket = iota // Don't use zero, that's a good invalid value
+
+	// The bucket indexed by height that has the raw oprblock data
+	//	Key -> Height
+	//	Value -> Graded opr list
+	BUCKET_OPR_HEIGHT
+
+	// These are unused
+	BUCKET_OPR        // Mostly Valid (has the prior winners, has proper structure
+	BUCKET_ALL_EB     // OPR chain Entry Blocks indexed by Directory Block Height
+	BUCKET_VALID_EB   // OPR chain Entry Blocks that actually qualify to pay out mining fees and set asset prices
+	BUCKET_VALID_OPRS // OPR Lists of valid OPRS, indexed by Directory Block Height, ordered as graded
+	BUCKET_BALANCES   // PNT payout balances
 )
 
 type Iterator interface {
@@ -29,4 +42,31 @@ type IDatabase interface {
 	Get(bucket Bucket, key []byte) ([]byte, error)
 	Delete(bucket Bucket, key []byte) error
 	Iterate(bucket Bucket) Iterator
+}
+
+func Decode(o interface{}, data []byte) error {
+	var buf bytes.Buffer
+	buf.Write(data)
+	dec := gob.NewDecoder(&buf)
+	err := dec.Decode(o)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Encode(o interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(o)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func HeightToBytes(v int64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(v))
+	return buf
 }

--- a/database/idatabase.go
+++ b/database/idatabase.go
@@ -44,6 +44,7 @@ type IDatabase interface {
 	Iterate(bucket Bucket) Iterator
 }
 
+// Decode is a gob decode into the target object
 func Decode(o interface{}, data []byte) error {
 	var buf bytes.Buffer
 	buf.Write(data)
@@ -55,6 +56,7 @@ func Decode(o interface{}, data []byte) error {
 	return nil
 }
 
+// Encode is a gob encode
 func Encode(o interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)

--- a/database/idatabase_test.go
+++ b/database/idatabase_test.go
@@ -1,0 +1,61 @@
+package database_test
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/pegnet/pegnet/opr"
+
+	. "github.com/pegnet/pegnet/database"
+)
+
+func TestDatabaseOverlay_Coding(t *testing.T) {
+
+	for i := 0; i < 100; i++ {
+		orig := RandomOPRBlock()
+		data, err := Encode(orig)
+		if err != nil {
+			t.Error(err)
+		}
+
+		newO := new(opr.OPRBlockDatabaseObject)
+		err = Decode(newO, data)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Check same going back in
+		data2, err := Encode(newO)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if bytes.Compare(data, data2) != 0 {
+			t.Error("encode is not the same after a decode")
+		}
+
+		if !reflect.DeepEqual(orig, newO) {
+			t.Error("new is not the same as the orig")
+		}
+
+	}
+
+}
+
+func RandomOPRBlock() *opr.OPRBlockDatabaseObject {
+	o := new(opr.OPRBlockDatabaseObject)
+
+	o.DblockHeight = rand.Int63n(1e6)
+	o.GradedOprs = make([]*opr.OraclePriceRecord, rand.Intn(100)+1)
+	for i := range o.GradedOprs {
+		tmp := new(opr.OraclePriceRecord)
+		tmp.OPRHash = make([]byte, 32)
+		rand.Read(tmp.OPRHash)
+		// TODO: Add more fields to this
+		o.GradedOprs[i] = tmp
+	}
+
+	return o
+}

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -27,7 +27,7 @@ type Ldb struct {
 // separated from the key by one zero. We set the high order bit
 func BuildKey(bucket Bucket, key []byte) (bkey []byte) {
 	for {
-		bkey = append(bkey, byte(bucket)|0x80)
+		bkey = append(key, byte(bucket)|0x80)
 		if bucket == 0 {
 			return bkey
 		}

--- a/database/mapdb.go
+++ b/database/mapdb.go
@@ -14,6 +14,13 @@ type MapDb struct {
 	lock sync.Mutex
 }
 
+func NewMapDb() *MapDb {
+	m := new(MapDb)
+	m.data = make(map[string][]byte)
+
+	return m
+}
+
 func (db *MapDb) Open(pathname string) (err error) {
 	db.data = make(map[string][]byte)
 	return

--- a/database/mapdb.go
+++ b/database/mapdb.go
@@ -1,0 +1,63 @@
+// Copyright (c) of parts are held by the various contributors (see the CLA)
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+package database
+
+import (
+	"sync"
+
+	"github.com/syndtr/goleveldb/leveldb/errors"
+)
+
+type MapDb struct {
+	data map[string][]byte
+	lock sync.Mutex
+}
+
+func (db *MapDb) Open(pathname string) (err error) {
+	db.data = make(map[string][]byte)
+	return
+}
+
+func (db *MapDb) Close() (err error) {
+	return nil
+}
+
+func (db *MapDb) Put(bucket Bucket, key []byte, Value []byte) error {
+	bkey := BuildKey(bucket, key)
+
+	db.lock.Lock() // make database access concurrent safe
+	defer db.lock.Unlock()
+	db.data[string(bkey)] = Value
+
+	return nil
+}
+
+func (db *MapDb) Get(bucket Bucket, key []byte) ([]byte, error) {
+	bkey := BuildKey(bucket, key)
+
+	db.lock.Lock() // make database access concurrent safe
+	defer db.lock.Unlock()
+
+	v, ok := db.data[string(bkey)]
+	if !ok {
+		return nil, errors.ErrNotFound
+	}
+
+	return v, nil
+}
+
+func (db *MapDb) Delete(bucket Bucket, key []byte) error {
+	bkey := BuildKey(bucket, key)
+
+	db.lock.Lock() // make database access concurrent safe
+	defer db.lock.Unlock()
+
+	delete(db.data, string(bkey))
+	return nil
+}
+
+// TODO: implement this for a map? Are we going to use this?
+func (db *MapDb) Iterate(bucket Bucket) (iter Iterator) {
+	return nil
+}

--- a/defaultconfig.ini
+++ b/defaultconfig.ini
@@ -43,6 +43,11 @@
 # Puts the logs in a file.  If not specified, logs are written to stdout
   LogFile=
 
+[Database]
+  # $PEGNETHOME defaults to ~/.pegnet
+  MinerDatabase=$PEGNETHOME/miner.ldb
+  MinerDatabaseType=ldb
+
 [Miner]
 
   # Options to setup a networked miner to a coordinator

--- a/networkMiner/client.go
+++ b/networkMiner/client.go
@@ -49,7 +49,7 @@ func NewMiningClient(config *config.Config) *MiningClient {
 	s.entryChannel = make(chan *factom.Entry, 25)
 	// The "Fakes" allow us to emit events
 	s.Monitor = common.NewFakeMonitor()
-	s.Grader = opr.NewFakeGrader()
+	s.Grader = opr.NewFakeGrader(config)
 	s.OPRMaker = mining.NewBlockingOPRMaker()
 
 	// We need to put our data in it

--- a/opr/assetList_test.go
+++ b/opr/assetList_test.go
@@ -103,6 +103,7 @@ func TestOPRJsonMarshal(t *testing.T) {
 
 	c := config.NewConfig([]config.Provider{common.NewUnitTestConfigProvider()})
 	o.CoinbaseAddress = common.ConvertRawToFCT(common.RandomByteSliceOfLen(32))
+	o.FactomDigitalID = "random"
 
 	for _, asset := range common.AllAssets {
 		o.Assets[asset] = rand.Float64() * 1000

--- a/opr/balances.go
+++ b/opr/balances.go
@@ -4,12 +4,10 @@
 package opr
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 
 	"github.com/pegnet/pegnet/common"
-	log "github.com/sirupsen/logrus"
 )
 
 // Balances holds the non-zero balances for every address for every token in a
@@ -50,14 +48,14 @@ func AddToBalance(address string, value int64) (err error) {
 	}
 	Balances[prefix][addressBytes] = prev + value
 
-	log.WithFields(log.Fields{
-		"address":       address,
-		"prefix":        prefix,
-		"address_bytes": hex.EncodeToString(addressBytes[:]),
-		"prev_balance":  prev,
-		"value":         value,
-		"new_balance":   prev + value,
-	}).Debug("Add to balance")
+	//log.WithFields(log.Fields{
+	//	"address":       address,
+	//	"prefix":        prefix,
+	//	"address_bytes": hex.EncodeToString(addressBytes[:]),
+	//	"prev_balance":  prev,
+	//	"value":         value,
+	//	"new_balance":   prev + value,
+	//}).Debug("Add to balance")
 	return
 }
 

--- a/opr/entryblocksync.go
+++ b/opr/entryblocksync.go
@@ -8,10 +8,10 @@ import (
 // EntryBlockSync has the current eblock synced to, and the target Eblock
 //	It also has the blocks in between in order. This makes it so traversing only needs to happen once
 type EntryBlockSync struct {
-	ChainID          string
-	Current          EntryBlockMarker
-	Target           EntryBlockMarker
-	BlocksToBeParsed []EntryBlockMarker
+	ChainID          string             // Chainid of the eblock chain
+	Current          EntryBlockMarker   // The current eblock we have synced
+	Target           EntryBlockMarker   // The target is the chainhead
+	BlocksToBeParsed []EntryBlockMarker // The eblocks between the current and target (including target)
 }
 
 func NewEntryBlockSync(chainid string) *EntryBlockSync {
@@ -21,6 +21,8 @@ func NewEntryBlockSync(chainid string) *EntryBlockSync {
 	return e
 }
 
+// SyncBlocks will query factomd and check if the chainhead has been updated,
+// and fill in the non synced eblocks
 func (a *EntryBlockSync) SyncBlocks() error {
 	// First check to see if the chainhead has been updated
 	expChainHead := a.Head()

--- a/opr/entryblocksync.go
+++ b/opr/entryblocksync.go
@@ -16,8 +16,6 @@ type EntryBlockSync struct {
 
 func NewEntryBlockSync(chainid string) *EntryBlockSync {
 	e := new(EntryBlockSync)
-	e.Current = *NewEntryBlockMarker()
-	e.Target = *NewEntryBlockMarker()
 	e.ChainID = chainid
 
 	return e
@@ -87,8 +85,9 @@ func (a *EntryBlockSync) BlockParsed(block EntryBlockMarker) {
 		panic("This block should not be next in the list")
 	}
 	a.Current = block
-	a.BlocksToBeParsed = make([]EntryBlockMarker, len(a.BlocksToBeParsed)-1)
-	copy(a.BlocksToBeParsed, a.BlocksToBeParsed[1:])
+	tmp := make([]EntryBlockMarker, len(a.BlocksToBeParsed)-1)
+	copy(tmp, a.BlocksToBeParsed[1:])
+	a.BlocksToBeParsed = tmp
 }
 
 func (a *EntryBlockSync) AddNewHead(keymr string, eblock *factom.EBlock) {
@@ -98,7 +97,7 @@ func (a *EntryBlockSync) AddNewHead(keymr string, eblock *factom.EBlock) {
 // AddNewHead will add a new eblock to be parsed to the head (tail of list)
 //	Since the block needs to be parsed, it is the new target and added to the blocks to be parsed
 func (a *EntryBlockSync) AddNewHeadMarker(marker EntryBlockMarker) {
-	if marker.EntryBlock.Header.BlockSequenceNumber < a.Target.EntryBlock.Header.BlockSequenceNumber {
+	if a.Target.KeyMr != "" && marker.EntryBlock.Header.BlockSequenceNumber < a.Target.EntryBlock.Header.BlockSequenceNumber {
 		return // Already added this target
 	}
 	a.BlocksToBeParsed = append(a.BlocksToBeParsed, marker)

--- a/opr/entryblocksync.go
+++ b/opr/entryblocksync.go
@@ -84,10 +84,11 @@ func (a *EntryBlockSync) NextEBlock() *EntryBlockMarker {
 // BlockParsed indicates a block has been parsed. We update our current
 func (a *EntryBlockSync) BlockParsed(block EntryBlockMarker) {
 	if !a.BlocksToBeParsed[0].IsSameAs(&block) {
-		panic("This block should be next in the list")
+		panic("This block should not be next in the list")
 	}
 	a.Current = block
-	a.BlocksToBeParsed = a.BlocksToBeParsed[1:]
+	a.BlocksToBeParsed = make([]EntryBlockMarker, len(a.BlocksToBeParsed)-1)
+	copy(a.BlocksToBeParsed, a.BlocksToBeParsed[1:])
 }
 
 func (a *EntryBlockSync) AddNewHead(keymr string, eblock *factom.EBlock) {

--- a/opr/entryblocksync.go
+++ b/opr/entryblocksync.go
@@ -1,0 +1,158 @@
+package opr
+
+import (
+	"github.com/FactomProject/factom"
+	"github.com/pegnet/pegnet/common"
+)
+
+// EntryBlockSync has the current eblock synced to, and the target Eblock
+//	It also has the blocks in between in order. This makes it so traversing only needs to happen once
+type EntryBlockSync struct {
+	ChainID          string
+	Current          EntryBlockMarker
+	Target           EntryBlockMarker
+	BlocksToBeParsed []EntryBlockMarker
+}
+
+func NewEntryBlockSync(chainid string) *EntryBlockSync {
+	e := new(EntryBlockSync)
+	e.Current = *NewEntryBlockMarker()
+	e.Target = *NewEntryBlockMarker()
+	e.ChainID = chainid
+
+	return e
+}
+
+func (a *EntryBlockSync) SyncBlocks() error {
+	// First check to see if the chainhead has been updated
+	expChainHead := a.Head()
+
+	heb, _, err := factom.GetChainHead(a.ChainID)
+	if err != nil {
+		return common.DetailError(err)
+	}
+
+	if expChainHead.KeyMr != heb {
+		// We have a new chainhead. This means we need to walk backwards in our entryblocks
+		// until we find our target. And add all the eblocks we are missing.
+		// From there we will have a clean Eblock sync to properly sync from, and use eblocks
+		// as checkpoints.
+		var eblocks []EntryBlockMarker
+		next := heb
+		for {
+			// If we found the target, we can stop
+			// Or if we found the first eblock in the chain, we can stop.
+			if next == expChainHead.KeyMr || next == common.ZeroHash {
+				break
+			}
+
+			eblock, err := factom.GetEBlock(next)
+			if err != nil {
+				return err
+			}
+
+			eblocks = append(eblocks, EntryBlockMarker{next, eblock})
+			next = eblock.Header.PrevKeyMR
+		}
+
+		// Add the blocks to our sync in the order they are on chain
+		for i := len(eblocks) - 1; i >= 0; i-- {
+			a.AddNewHeadMarker(eblocks[i])
+		}
+	}
+	return nil
+}
+
+// Synced returns if fully synced (current == target)
+func (a *EntryBlockSync) Synced() bool {
+	return a.Current.IsSameAs(&a.Target)
+}
+
+// Head returns our target head. This is the chainhead that we know of
+func (a *EntryBlockSync) Head() EntryBlockMarker {
+	return a.Target
+}
+
+// NextEBlock returns the next eblock that is needed to be parsed
+func (a *EntryBlockSync) NextEBlock() *EntryBlockMarker {
+	if len(a.BlocksToBeParsed) == 0 {
+		return nil
+	}
+	return &a.BlocksToBeParsed[0]
+}
+
+// BlockParsed indicates a block has been parsed. We update our current
+func (a *EntryBlockSync) BlockParsed(block EntryBlockMarker) {
+	if !a.BlocksToBeParsed[0].IsSameAs(&block) {
+		panic("This block should be next in the list")
+	}
+	a.Current = block
+	a.BlocksToBeParsed = a.BlocksToBeParsed[1:]
+}
+
+func (a *EntryBlockSync) AddNewHead(keymr string, eblock *factom.EBlock) {
+	a.AddNewHeadMarker(EntryBlockMarker{keymr, eblock})
+}
+
+// AddNewHead will add a new eblock to be parsed to the head (tail of list)
+//	Since the block needs to be parsed, it is the new target and added to the blocks to be parsed
+func (a *EntryBlockSync) AddNewHeadMarker(marker EntryBlockMarker) {
+	if marker.EntryBlock.Header.BlockSequenceNumber < a.Target.EntryBlock.Header.BlockSequenceNumber {
+		return // Already added this target
+	}
+	a.BlocksToBeParsed = append(a.BlocksToBeParsed, marker)
+	a.Target = marker
+}
+
+func (a *EntryBlockSync) IsSameAs(b *EntryBlockSync) bool {
+	if !a.Current.IsSameAs(&b.Current) {
+		return false
+	}
+	if !a.Target.IsSameAs(&b.Target) {
+		return false
+	}
+
+	if len(a.BlocksToBeParsed) != len(b.BlocksToBeParsed) {
+		return false
+	}
+
+	for i := range a.BlocksToBeParsed {
+		if !a.BlocksToBeParsed[i].IsSameAs(&b.BlocksToBeParsed[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type EntryBlockMarkerList []EntryBlockMarker
+
+func (p EntryBlockMarkerList) Len() int {
+	return len(p)
+}
+
+func (p EntryBlockMarkerList) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+func (p EntryBlockMarkerList) Less(i, j int) bool {
+	return p[i].EntryBlock.Header.BlockSequenceNumber < p[j].EntryBlock.Header.BlockSequenceNumber
+}
+
+type EntryBlockMarker struct {
+	KeyMr      string
+	EntryBlock *factom.EBlock
+}
+
+func NewEntryBlockMarker() *EntryBlockMarker {
+	e := new(EntryBlockMarker)
+	return e
+}
+
+func (a *EntryBlockMarker) IsSameAs(b *EntryBlockMarker) bool {
+	// Keymrs should be uniq to the eblock
+	if a.KeyMr != b.KeyMr {
+		return false
+	}
+	return true
+}

--- a/opr/entryblocksync_test.go
+++ b/opr/entryblocksync_test.go
@@ -1,0 +1,29 @@
+package opr_test
+
+import (
+	"testing"
+
+	. "github.com/pegnet/pegnet/opr"
+)
+
+func TestEntryBlockSync_AddNewHeadMarker(t *testing.T) {
+	e := NewEntryBlockSync("test")
+	if e.NextEBlock() != nil {
+		t.Errorf("exp a nil")
+	}
+
+	e.AddNewHeadMarker(EntryBlockMarker{KeyMr: "test1"})
+	if b := e.NextEBlock(); b == nil {
+		t.Errorf("block is nil")
+	} else {
+		if b.KeyMr != "test1" {
+			t.Errorf("not expected block")
+		}
+		e.BlockParsed(*b)
+	}
+
+	if e.NextEBlock() != nil {
+		t.Errorf("exp a nil")
+	}
+
+}

--- a/opr/fct2pFct.go
+++ b/opr/fct2pFct.go
@@ -10,18 +10,20 @@ import (
 
 var FctDbht int64
 
-func UpdateBurns(c *config.Config) {
+// TODO: Rework this a bit to handle errors
+func UpdateBurns(c *config.Config, grader *QuickGrader) {
 
 	network, err := common.LoadConfigNetwork(c)
 	if err != nil {
 		panic("cannot find the network designation for updating burn txs")
 	}
 
-	if len(OPRBlocks) == 0 {
-		return // There is nothing to do if there is no OPR chain with valid OPR blocks
-	}
 	if FctDbht == 0 {
-		FctDbht = OPRBlocks[0].Dbht
+		block := grader.GetFirstOPRBlock()
+		if block == nil {
+			return // There is nothing to do if there is no OPR chain with valid OPR blocks
+		}
+		FctDbht = block.Dbht
 	}
 	for i := FctDbht + 1; ; i++ {
 		fc, _, _ := factom.GetFBlockByHeight(i)

--- a/opr/grader_fake.go
+++ b/opr/grader_fake.go
@@ -3,14 +3,16 @@
 
 package opr
 
+import "github.com/zpatrick/go-config"
+
 // FakeGrader can be used in unit tests
 type FakeGrader struct {
-	*Grader
+	*QuickGrader
 }
 
-func NewFakeGrader() *FakeGrader {
+func NewFakeGrader(config *config.Config) *FakeGrader {
 	f := new(FakeGrader)
-	f.Grader = NewGrader()
+	f.QuickGrader = NewQuickGrader(config)
 
 	return f
 }

--- a/opr/grader_fake.go
+++ b/opr/grader_fake.go
@@ -3,7 +3,10 @@
 
 package opr
 
-import "github.com/zpatrick/go-config"
+import (
+	"github.com/pegnet/pegnet/database"
+	"github.com/zpatrick/go-config"
+)
 
 // FakeGrader can be used in unit tests
 type FakeGrader struct {
@@ -12,7 +15,7 @@ type FakeGrader struct {
 
 func NewFakeGrader(config *config.Config) *FakeGrader {
 	f := new(FakeGrader)
-	f.QuickGrader = NewQuickGrader(config)
+	f.QuickGrader = NewQuickGrader(config, database.NewMapDb())
 
 	return f
 }

--- a/opr/grader_test.go
+++ b/opr/grader_test.go
@@ -1,0 +1,50 @@
+package opr_test
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/pegnet/pegnet/database"
+	. "github.com/pegnet/pegnet/opr"
+)
+
+func TestOPRBlockStore(t *testing.T) {
+	o := NewOPRBlockStore(database.NewMapDb())
+	var err error
+	for i := 0; i < 100; i++ {
+		orig := RandomOPRBlock()
+
+		err = o.WriteOPRBlock(orig.ToOPRBlock())
+		if err != nil {
+			t.Error(err)
+		}
+
+		newO, err := o.FetchOPRBlock(orig.DblockHeight)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(orig.ToOPRBlock(), newO) {
+			t.Error("new is not the same as the orig")
+		}
+
+	}
+
+}
+
+func RandomOPRBlock() *OPRBlockDatabaseObject {
+	o := new(OPRBlockDatabaseObject)
+
+	o.DblockHeight = rand.Int63n(1e6)
+	o.GradedOprs = make([]*OraclePriceRecord, rand.Intn(100)+1)
+	for i := range o.GradedOprs {
+		tmp := new(OraclePriceRecord)
+		tmp.OPRHash = make([]byte, 32)
+		rand.Read(tmp.OPRHash)
+		// TODO: Add more fields to this
+		o.GradedOprs[i] = tmp
+	}
+
+	return o
+}

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -4,18 +4,11 @@
 package opr
 
 import (
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"sort"
-	"sync"
 
-	"github.com/FactomProject/factom"
-	"github.com/dustin/go-humanize"
 	"github.com/pegnet/pegnet/common"
-	log "github.com/sirupsen/logrus"
-	"github.com/zpatrick/go-config"
 )
 
 // Avg computes the average answer for the price of each token reported
@@ -150,174 +143,6 @@ type OprBlock struct {
 	Dbht       int64
 }
 
-// OPRBlocks holds all the known OPRs
-var OPRBlocks []*OprBlock
-
-var ebMutex sync.Mutex
-
-// GetEntryBlocks creates the OPR Records at a given dbht
-func GetEntryBlocks(config *config.Config) error {
-	ebMutex.Lock()
-	defer UpdateBurns(config)
-	defer ebMutex.Unlock()
-
-	network, err := common.LoadConfigNetwork(config)
-	common.CheckAndPanic(err)
-	p, err := config.String("Miner.Protocol")
-	common.CheckAndPanic(err)
-	n, err := common.LoadConfigNetwork(config)
-	common.CheckAndPanic(err)
-	opr := [][]byte{[]byte(p), []byte(n), []byte(common.OPRChainTag)}
-
-	heb, _, err := factom.GetChainHead(hex.EncodeToString(common.ComputeChainIDFromFields(opr)))
-	if err != nil {
-		return common.DetailError(err)
-	}
-	eb, err := factom.GetEBlock(heb)
-	if err != nil {
-		return common.DetailError(err)
-	}
-
-	// A temp list of candidate oprblocks to evaluate to see if they fit nicely together
-	// Because we go from the head of the chain backwards to collect them, they have to be
-	// collected before I can then validate them forward from the highest valid OPR block
-	// I have found.
-	var oprblocks []*OprBlock
-	// For each entryblock in the Oracle Price Records chain
-	// Get all the valid OPRs and put them in  a new OPRBlock structure
-	for eb != nil && (len(OPRBlocks) == 0 ||
-		eb.Header.DBHeight > OPRBlocks[len(OPRBlocks)-1].Dbht) {
-		// Go through the Entry Block and collect all the valid OPR records
-		// To have even a chance of being good, we need 10 records in the Entry Block
-		if len(eb.EntryList) >= 10 {
-			oprblk := new(OprBlock)
-			oprblk.Dbht = eb.Header.DBHeight
-			for _, ebentry := range eb.EntryList {
-				entry, err := factom.GetEntry(ebentry.EntryHash)
-				if err != nil {
-					return common.DetailError(err)
-				}
-
-				// Do some quick collecting of data and checks of the entry.
-				// Can only have two ExtIDs which must be:
-				//	[0] the nonce for the entry
-				//	[1] Self reported difficulty
-				if len(entry.ExtIDs) != 3 {
-					continue // keep looking if the entry has more than one extid
-				}
-
-				// Okay, it looks sort of okay.  Lets unmarshal the JSON
-				opr := NewOraclePriceRecord()
-				if err := json.Unmarshal(entry.Content, opr); err != nil {
-					continue // Doesn't unmarshal, then it isn't valid for sure.  Continue on.
-				}
-				if opr.CoinbasePNTAddress, err = common.ConvertFCTtoPegNetAsset(network, "PNT", opr.CoinbaseAddress); err != nil {
-					continue
-				}
-				// Run some basic checks on the values.  If they don't check out, then ignore the entry
-				if !opr.Validate(config, oprblk.Dbht) {
-					continue
-				}
-				// Keep this entry
-				opr.EntryHash = entry.Hash()
-				opr.Nonce = entry.ExtIDs[0]
-				opr.SelfReportedDifficulty = entry.ExtIDs[1]
-				if len(entry.ExtIDs[2]) != 1 {
-					continue // Version is 1 byte
-				}
-				opr.Version = entry.ExtIDs[2][0]
-
-				// Looking good.  Go ahead and compute the OPRHash
-				sha := sha256.Sum256(entry.Content)
-				opr.OPRHash = sha[:] // Save the OPRHash
-
-				// Okay, mostly good.  Add to our candidate list
-				oprblk.OPRs = append(oprblk.OPRs, opr)
-
-			}
-			// If we have 10 canidates, then lets add them up.
-			if len(oprblk.OPRs) >= 10 {
-				oprblocks = append(oprblocks, oprblk)
-			}
-		}
-		// At this point, the oprblk has all the valid OPRs. Make sure we have enough.
-		// sorted list of winners.
-
-		neb, err := factom.GetEBlock(eb.Header.PrevKeyMR)
-		if err != nil {
-			break
-		}
-		eb = neb
-	}
-
-	// Take the reverse ordered opr blocks, from last to first.  Validate all the winners are
-	// the right winners.  Replace the generally correct OPR list in the opr block with the
-	// list of winners.  These should be the winners of the next block, which lucky enough is
-	// the next block we are going to process.
-	// Ignore opr blocks that don't get 10 winners.
-	for i := len(oprblocks) - 1; i >= 0; i-- { // Okay, go through these backwards
-		var validOPRs []*OraclePriceRecord // Collect the valid OPRPriceRecords here
-
-		var previousWinners []*OraclePriceRecord
-		prevblock := GetPreviousOPRBlock(int32(oprblocks[i].Dbht))
-		if prevblock != nil {
-			previousWinners = prevblock.GradedOPRs
-		}
-
-		for _, opr := range oprblocks[i].OPRs { // Go through this block
-			if !VerifyWinners(opr, previousWinners) {
-				continue
-			}
-			opr.Difficulty = opr.ComputeDifficulty(opr.Nonce)
-
-			f := binary.BigEndian.Uint64(opr.SelfReportedDifficulty)
-			if f != opr.Difficulty {
-				// TODO Maybe we should log.warn how many per block are 'malicious'?
-				log.Errorf("Diff mistmatch. Exp %d, found %d", opr.Difficulty, f)
-				continue
-			}
-
-			validOPRs = append(validOPRs, opr) // Add to my valid list if all the winners are right
-		}
-
-		if len(validOPRs) < 10 { // Make sure we have at least 10 valid OPRs,
-			continue // and leave if we don't.
-		}
-		gradedOPRs, sortedOPRs := GradeBlock(validOPRs)
-		oprblocks[i].GradedOPRs = gradedOPRs
-		oprblocks[i].OPRs = sortedOPRs
-		OPRBlocks = append(OPRBlocks, oprblocks[i])
-
-		// Update the balances for each winner
-		for place, winner := range gradedOPRs[:10] {
-			reward := GetRewardFromPlace(place)
-			if reward > 0 {
-				err := AddToBalance(winner.CoinbasePNTAddress, reward)
-				if err != nil {
-					log.WithError(err).Fatal("Failed to update balance")
-				}
-			}
-			if i == 0 {
-				logger := log.WithFields(log.Fields{
-					"place":      place,
-					"id":         winner.FactomDigitalID,
-					"entry_hash": hex.EncodeToString(winner.EntryHash[:8]),
-					"grade":      common.FormatGrade(winner.Grade, 4),
-					"difficulty": common.FormatDiff(winner.Difficulty, 10),
-					"address":    winner.CoinbasePNTAddress,
-					"balance":    humanize.Comma(GetBalance(winner.CoinbasePNTAddress)),
-				})
-				if place == 0 {
-					logger.Info("New OPR Winner")
-				} else {
-					logger.Debug("New OPR Winner")
-				}
-			}
-		}
-	}
-	return nil
-}
-
 // VerifyWinners takes an opr and compares its list of winners to the winners of previousHeight
 func VerifyWinners(opr *OraclePriceRecord, winners []*OraclePriceRecord) bool {
 	for i, w := range opr.WinPreviousOPR {
@@ -329,26 +154,6 @@ func VerifyWinners(opr *OraclePriceRecord, winners []*OraclePriceRecord) bool {
 		}
 	}
 	return true
-}
-
-// GetPreviousOPRBlock returns the winners of the previous OPR block
-func GetPreviousOPRBlock(dbht int32) *OprBlock {
-	for i := len(OPRBlocks) - 1; i >= 0; i-- {
-		if OPRBlocks[i].Dbht < int64(dbht) {
-			return OPRBlocks[i]
-		}
-	}
-	return nil
-}
-
-// GetPreviousOPRs returns the OPRs in highest-known block less than dbht.
-// Returns nil if the dbht is the first dbht in the chain.
-func GetPreviousOPRs(dbht int32) []*OraclePriceRecord {
-	block := GetPreviousOPRBlock(dbht)
-	if block != nil {
-		return block.OPRs
-	}
-	return nil
 }
 
 func GetRewardFromPlace(place int) int64 {

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -187,7 +187,6 @@ func GetEntryBlocks(config *config.Config) error {
 	// Get all the valid OPRs and put them in  a new OPRBlock structure
 	for eb != nil && (len(OPRBlocks) == 0 ||
 		eb.Header.DBHeight > OPRBlocks[len(OPRBlocks)-1].Dbht) {
-
 		// Go through the Entry Block and collect all the valid OPR records
 		// To have even a chance of being good, we need 10 records in the Entry Block
 		if len(eb.EntryList) >= 10 {

--- a/opr/grading.go
+++ b/opr/grading.go
@@ -138,9 +138,10 @@ func RemoveDuplicateSubmissions(list []*OraclePriceRecord) []*OraclePriceRecord 
 
 // block data at a specific height
 type OprBlock struct {
-	OPRs       []*OraclePriceRecord
-	GradedOPRs []*OraclePriceRecord
-	Dbht       int64
+	OPRs          []*OraclePriceRecord
+	GradedOPRs    []*OraclePriceRecord
+	Dbht          int64
+	EmptyOPRBlock bool // An empty opr block is an eblock that could not totally validate
 }
 
 // VerifyWinners takes an opr and compares its list of winners to the winners of previousHeight

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/FactomProject/btcutil/base58"
 	"github.com/FactomProject/factom"
-	"github.com/dustin/go-humanize"
 	lxr "github.com/pegnet/LXRHash"
 	"github.com/pegnet/pegnet/common"
 	"github.com/pegnet/pegnet/polling"
@@ -230,22 +229,13 @@ func (opr *OraclePriceRecord) String() (str string) {
 
 	str = str + fmt.Sprintf("\nWinners\n\n")
 
-	pwin := GetPreviousOPRs(opr.Dbht - 1)
-
 	// If there were previous winners, we need to make sure this miner is running
 	// the software to detect them, and that we agree with their conclusions.
-	if pwin != nil {
-		for i, v := range opr.WinPreviousOPR {
-			balance := GetBalance(pwin[i].CoinbasePNTAddress)
-			hbal := humanize.Comma(balance)
-			str = str + fmt.Sprintf("   %16s %16x %30s %-56s = %10s\n",
-				v,
-				pwin[i].EntryHash[:8],
-				pwin[i].FactomDigitalID,
-				pwin[i].CoinbasePNTAddress,
-				hbal,
-			)
-		}
+	for i, v := range opr.WinPreviousOPR {
+		str = str + fmt.Sprintf("   %2d\t%16s\n",
+			i,
+			v,
+		)
 	}
 	return str
 }

--- a/opr/opr.go
+++ b/opr/opr.go
@@ -135,6 +135,10 @@ func (opr *OraclePriceRecord) Validate(c *config.Config, dbht int64) bool {
 		}
 	}
 
+	if err := common.ValidIdentity(opr.FactomDigitalID); err != nil {
+		return false
+	}
+
 	if int64(opr.Dbht) != dbht {
 		return false // DBHeight is not reported correctly
 	}

--- a/opr/oprblocks.go
+++ b/opr/oprblocks.go
@@ -1,0 +1,95 @@
+package opr
+
+import (
+	"encoding/gob"
+	"sort"
+
+	"github.com/pegnet/pegnet/database"
+)
+
+// OPRBlockStore is where we store the oprblock list
+type OPRBlockStore struct {
+	DB database.IDatabase
+}
+
+func NewOPRBlockStore(db database.IDatabase) *OPRBlockStore {
+	o := new(OPRBlockStore)
+	gob.Register(OPRBlockDatabaseObject{})
+	o.DB = db
+
+	return o
+}
+
+// WriteInvalidOPRBlock is for writing a dbht to disk that has an invalid oprblock. This could
+// be because the oprblock does not have enough entries, or another error
+func (d *OPRBlockStore) WriteInvalidOPRBlock(dbht int64) error {
+	// An invalid oprblock is
+	oprblock := new(OprBlock)
+	oprblock.EmptyOPRBlock = true
+	oprblock.Dbht = dbht
+
+	return d.WriteOPRBlock(oprblock)
+}
+
+// WriteOPRBlock will write the top 50 graded oprs and write their corresponding indexes
+func (d *OPRBlockStore) WriteOPRBlock(opr *OprBlock) error {
+	// And opr block has both a graded component and sorted by difficulty component.
+	// To save space, we can just keep the graded component, and resort the oprs when we pull them.
+
+	obj := OPRBlockDatabaseObject{
+		GradedOprs:    opr.GradedOPRs,
+		DblockHeight:  opr.Dbht,
+		EmptyOPRBlock: opr.EmptyOPRBlock,
+	}
+
+	data, err := database.Encode(obj)
+	if err != nil {
+		return err
+	}
+
+	// The multiple indexes. First we write the OPR block to the first index by height. This is where
+	// the raw data will live
+	err = d.DB.Put(database.BUCKET_OPR_HEIGHT, database.HeightToBytes(obj.DblockHeight), data)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add more indexing if you need more
+
+	return nil
+}
+
+func (d *OPRBlockStore) FetchOPRBlock(height int64) (*OprBlock, error) {
+	obj := new(OPRBlockDatabaseObject)
+
+	data, err := d.DB.Get(database.BUCKET_OPR_HEIGHT, database.HeightToBytes(height))
+	if err != nil {
+		return nil, err
+	}
+
+	err = database.Decode(obj, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.ToOPRBlock(), nil
+}
+
+type OPRBlockDatabaseObject struct {
+	GradedOprs    []*OraclePriceRecord
+	DblockHeight  int64
+	EmptyOPRBlock bool
+}
+
+func (o *OPRBlockDatabaseObject) ToOPRBlock() *OprBlock {
+	oprBlock := new(OprBlock)
+	oprBlock.Dbht = o.DblockHeight
+	oprBlock.GradedOPRs = o.GradedOprs
+	oprBlock.OPRs = make([]*OraclePriceRecord, len(oprBlock.GradedOPRs))
+	copy(oprBlock.OPRs, oprBlock.GradedOPRs)
+	oprBlock.EmptyOPRBlock = o.EmptyOPRBlock
+
+	sort.SliceStable(oprBlock.OPRs, func(i, j int) bool { return oprBlock.OPRs[i].Difficulty > oprBlock.OPRs[j].Difficulty })
+
+	return oprBlock
+}

--- a/opr/recorder.go
+++ b/opr/recorder.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pegnet/pegnet/database"
+
 	"github.com/pegnet/pegnet/common"
 
 	log "github.com/sirupsen/logrus"
@@ -39,7 +41,7 @@ func (c *ChainRecorder) WriteMinerCSV() error {
 	file := f
 	writer := csv.NewWriter(file)
 
-	g := NewQuickGrader(c.config)
+	g := NewQuickGrader(c.config, database.NewMapDb())
 	err = g.Sync()
 	if err != nil {
 		return err


### PR DESCRIPTION
The grader has been redone. The previous iteration would regrade some blocks and it used a global as the oprblock storage. This refactor moves the global state into a struct and will only grade each entry block once. 

## Grader Syncing
The basics of the new grader is that we first sync the eblocks from the network. Once we have the eblocks in their sequence, we can sync each eblock one by one, marking them synced as we walk through the chain. This style of syncing was used in factomd for identities, as you only sync heights with data we are concerned about (since we hope eblock to eblock, ignoring the dblocks). It makes keeping track of a sync simpler, as the prior code would use a sorted block height order to verify the order of oprs was correct. This uses the natural chaining of eblocks, and handles height skips gracefully.

This eblock syncing behavior was moved into it's own struct if we wish to reuse it for another chain syncing.

## Grader Optimiziation

The grading used to compute the difficulty of all the oprs in a block, now we only do the top 50 honest records. With the change to sha256, this is less important, but can really help speed up syncing as the chain grows.

## Grader Database

I didn't want to save the entire state to the database, as that could be prone to more errors, and did not want to undertake that at this time. However, grader syncing is already starting to take a good amount of time if using a remote factomd node (15m on the older grader to a factomd over LAN). I added multithread entry retrival and got that sync time down to 3min, but 3min for each boot is still slow. There is now a database that stores the graded oprs for a given eblock, making the sync time 6s to my factomd across LAN after it's been synced once. This can be further speedup by saving the eblock syncing part, but I did not feel that necessary atm.

## Further notes

I think we should drop a lot of the state we are saving in the miner, mainly to support the apis. I suggest we create a different daemon `pegnet node` that can store all the information to support the apis. We are overloading the miner, and increasing the memory footprint for a miner that might be running in low resource environments. If we drop the api, and instead support a very basic set of endpoints, we can create a better pegnet node with better database indexing for the rest of people's needs.

This is the start of splitting the `miner` and the `node`. I want to get away from the globals so we can easily split things apart and not be sharing globals where the data format is fixed.

Addresses issues:
- https://github.com/pegnet/pegnet/issues/236
- https://github.com/pegnet/pegnet/issues/237