### PR TITLE
Fixed collision on port 8088 for default config

### DIFF
--- a/config/defaultconfig.ini
+++ b/config/defaultconfig.ini
@@ -53,7 +53,7 @@
 
 [API]
   APIPort=8099
-  ControlPanelPort=8088
+  ControlPanelPort=8080
 
 [Miner]
   # Factom Connection Options (if using Docker, use values below)

--- a/controlPanel/controlPanel.go
+++ b/controlPanel/controlPanel.go
@@ -84,8 +84,6 @@ type CommonResponse struct {
 }
 
 func (c *ControlPanel) ServeControlPanel() {
-	log.Info("Starting control panel on localhost:8080")
-
 	alert := c.Monitor.NewListener()
 	statsUpStream := c.Statistics.GetUpstream("control-panel")
 
@@ -132,6 +130,9 @@ func (c *ControlPanel) ServeControlPanel() {
 	if err != nil {
 		panic(fmt.Sprintf("Do not have a control panel port in the config file: %v", err))
 	}
+	log.WithFields(log.Fields{
+		"port": port,
+	}).Info("Starting control panel")
 	c.Listen(port)
 
 }


### PR DESCRIPTION
Control panel was failing with the default config due to it being set to 8088