### PR TITLE
PNT-294: stale polling

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -230,13 +230,13 @@ var datasources = &cobra.Command{
 		"opposite; given an asset what datasources include it.",
 	Example:   "pegnet datasources FCT\npegnet datasources CoinMarketCap",
 	Args:      CombineCobraArgs(CustomArgOrderValidationBuilder(false, ArgValidatorAssetOrExchange)),
-	ValidArgs: append(common.AllAssets, polling.AllDataSourcesList()...),
+	ValidArgs: append(common.AssetsV2, polling.AllDataSourcesList()...),
 	Run: func(cmd *cobra.Command, args []string) {
 		ValidateConfig(Config) // Will fatal log if it fails
 
 		// User selected a data source or asset
 		if len(args) == 1 {
-			if common.AssetListContainsCaseInsensitive(common.AllAssets, args[0]) {
+			if common.AssetListContainsCaseInsensitive(common.AssetsV2, args[0]) {
 				// Specified an asset
 				asset := strings.ToUpper(args[0])
 
@@ -280,10 +280,7 @@ var datasources = &cobra.Command{
 
 		fmt.Println()
 		fmt.Println("Assets and their data source order. The order left to right is the fallback order.")
-		for _, asset := range common.AllAssets {
-			if asset == "PEG" {
-				continue
-			}
+		for _, asset := range common.AssetsV2 {
 			str := d.AssetPriorityString(asset)
 			fmt.Printf("\t%4s (%d) : %s\n", asset, len(d.AssetSources[asset]), str)
 		}

--- a/common/config.go
+++ b/common/config.go
@@ -108,6 +108,7 @@ func NewUnitTestConfigProvider() *UnitTestConfigProvider {
   OpenExchangeRatesKey=CHANGEME
   CoinMarketCapKey=CHANGEME
   1ForgeKey=CHANGEME
+  StaleQuoteDuration=10m
 
 
 [OracleDataSources]

--- a/common/config.go
+++ b/common/config.go
@@ -29,6 +29,10 @@ const (
 
 	ConfigCoinMarketCapKey = "Oracle.CoinMarketCapKey"
 	Config1ForgeKey        = "Oracle.1ForgeKey"
+
+	// ConfigStaleDuration determines how old a quote is allowed to be and still be
+	// acceptable
+	ConfigStaleDuration = "Oracle.StaleQuoteDuration"
 )
 
 // DefaultConfigOptions gives us the ability to add configurable settings that really
@@ -53,12 +57,13 @@ func (c *DefaultConfigOptions) Load() (map[string]string, error) {
 	settings[ConfigMinerDBType] = "ldb"
 	settings[ConfigPegnetNodeDBPath] = "$PEGNETHOME/data_$PEGNETNETWORK/node.sqlite"
 	settings[ConfigControlPanelPort] = "8080"
+	settings[ConfigStaleDuration] = "10m"
 
 	return settings, nil
 }
 
 func NewUnitTestConfig() *config.Config {
-	return config.NewConfig([]config.Provider{NewUnitTestConfigProvider()})
+	return config.NewConfig([]config.Provider{NewDefaultConfigOptionsProvider(), NewUnitTestConfigProvider()})
 }
 
 // UnitTestConfigProvider is only used in unit tests.

--- a/common/config.go
+++ b/common/config.go
@@ -57,7 +57,7 @@ func (c *DefaultConfigOptions) Load() (map[string]string, error) {
 	settings[ConfigMinerDBType] = "ldb"
 	settings[ConfigPegnetNodeDBPath] = "$PEGNETHOME/data_$PEGNETNETWORK/node.sqlite"
 	settings[ConfigControlPanelPort] = "8080"
-	settings[ConfigStaleDuration] = "10m"
+	settings[ConfigStaleDuration] = "30m"
 
 	return settings, nil
 }

--- a/config/defaultconfig.ini
+++ b/config/defaultconfig.ini
@@ -116,6 +116,10 @@
   # Must get an api key here https://1forge.com/forex-data-api
   1ForgeKey=CHANGEME
 
+  # If a quote is beyond this time old, we will fallback to additional
+  # datasources, and return the most recent price quote we can find.
+  StaleQuoteDuration=30m
+
 
 # This section must ONLY include data sources and their priorities. Any configuration
 # related to a source should be specified in the [Oracle] section.

--- a/config/defaultconfig.ini
+++ b/config/defaultconfig.ini
@@ -129,6 +129,10 @@
   # This is not a website, this is a hardcoded '1'. Don't change this
   FixedUSD=0
 
+  # Always enable this to some rank. It puts PEG at 0 usd until PEG
+  # has a value. This must be enabled! This is not a website.
+  FixedPEG=1
+
   # ----------------
   # Paid Sources
   APILayer=-1
@@ -143,7 +147,7 @@
   # ----------------
   #  Free sources, no signup required
   FreeForexAPI=3
-  AlternativeMe=1
+  AlternativeMe=2
   CoinCap=-1
 
   #   Web scraping, rank it low

--- a/opr/recorder.go
+++ b/opr/recorder.go
@@ -124,7 +124,7 @@ func (c *ChainRecorder) WriteMinerCSV() error {
 	// Build the csv
 	for i, block := range g.GetBlocks() {
 		var _ = i
-		last := 50
+		last := 49
 		if len(block.GradedOPRs) < 50 {
 			last = len(block.GradedOPRs) - 1
 		}

--- a/polling/README.md
+++ b/polling/README.md
@@ -1,0 +1,33 @@
+# Data Source Notes
+
+## 1Forge
+
+## AlternativeMe
+
+- Updates every 5 minutes
+
+## ApiLayer
+
+- Every Minute updates
+
+## Coincap
+
+- Says every second it updates
+
+## CMC
+
+- Every minute or so updating
+
+## Exchange Rates
+
+- Updates daily except on closing dates
+
+## FreeForex
+
+- Updates every minute
+
+## Kitco
+
+## OpenExchange Rates
+
+- Update frequency depends on your service tier

--- a/polling/alternative.go
+++ b/polling/alternative.go
@@ -14,6 +14,8 @@ import (
 )
 
 // AlternativeMeDataSource is the datasource at https://alternative.me/crypto/api/
+//	Notes:
+//		- Price quotes are every 5 minutes
 type AlternativeMeDataSource struct {
 	config *config.Config
 }

--- a/polling/alternative_test.go
+++ b/polling/alternative_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func TestActualAlternativePeggedAssets(t *testing.T) {
-	ActualDataSourceTest(t, "AlternativeMe")
-}
+//func TestActualAlternativePeggedAssets(t *testing.T) {
+//	ActualDataSourceTest(t, "AlternativeMe")
+//}
 
 func TestFixedAlternativePeggedAssets(t *testing.T) {
 	FixedDataSourceTest(t, "AlternativeMe", []byte(alternativeResp))

--- a/polling/alternative_test.go
+++ b/polling/alternative_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-//func TestActualAlternativePeggedAssets(t *testing.T) {
-//	ActualDataSourceTest(t, "AlternativeMe")
-//}
+func TestActualAlternativePeggedAssets(t *testing.T) {
+	ActualDataSourceTest(t, "AlternativeMe")
+}
 
 func TestFixedAlternativePeggedAssets(t *testing.T) {
 	FixedDataSourceTest(t, "AlternativeMe", []byte(alternativeResp))

--- a/polling/apilayer_test.go
+++ b/polling/apilayer_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 )
 
+// Need an api key to run this
+//func TestActualApiLayerPeggedAssets(t *testing.T) {
+//	ActualDataSourceTest(t, "APILayer")
+//}
+
 // TestFixedApiLayerPeggedAssets tests all the crypto assets are found on ApiLayer
 func TestFixedApiLayerPeggedAssets(t *testing.T) {
 	FixedDataSourceTest(t, "APILayer", []byte(apiLayerReponse))

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -332,10 +332,12 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 			prices = append(prices, price)
 
 			// We can break out if this is a 'good' price
-			//	Is it stale?
-			if reference.Sub(price.When) > d.staleDuration {
+			//	Is it stale AND the market is open? We can expect stale quotes in a closed market
+			if reference.Sub(price.When) > d.staleDuration && IsMarketOpen(asset, reference) {
 				// This price quote is stale, keep fetching prices
-				continue
+				if IsMarketOpen(asset, reference) {
+					continue
+				}
 			}
 
 			// This price is acceptable

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -349,14 +349,19 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 		return
 	}
 
-	// Now we iterate over the prices we found, and return the most recent quote
-	for _, price := range prices {
-		// if the existing value is before the new price, the new price is more recent.
-		if pa.When.Before(price.When) {
-			pa = price
-		}
+	// If we got here, that means that there might exist some price quotes from
+	// our data sources, but they are all stale. Instead of taking the most recent price
+	// quote, we will take the highest priority quote given our data-source order.
+	if len(prices) > 0 {
+		pa = prices[0]
+		return pa, nil
 	}
 
+	// If no prices exist, this could mean we had no data-sources configured for this
+	// asset. We will just return a blank quote, vs throwing an error.
+	// The best price for an asset with no data-source is 0. The OPR creation should
+	// check if the 0 value is valid, not this polling function.
+	// E.g: PEG will return 0 as there is no configured data-sources for it.
 	return pa, nil
 }
 

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -22,6 +22,7 @@ var AllDataSources = map[string]IDataSource{
 	"APILayer": new(APILayerDataSource),
 	"CoinCap":  new(CoinCapDataSource),
 	"FixedUSD": new(FixedUSDDataSource),
+	"FixedPEG": new(FixedPEGDataSource),
 	// ExchangeRates is daily,  don't show people this
 	//"ExchangeRates":     new(ExchangeRatesDataSource),
 	"Kitco": new(KitcoDataSource),
@@ -90,6 +91,8 @@ func NewDataSource(source string, config *config.Config) (IDataSource, error) {
 		ds, err = NewOneForgeDataSourceDataSource(config)
 	case "FixedUSD":
 		ds, err = NewFixedUSDDataSource(config)
+	case "FixedPEG":
+		ds, err = NewFixedPEGDataSource(config)
 	case "AlternativeMe":
 		ds, err = NewAlternativeMeDataSource(config)
 	case "UnitTest": // This will fail outside a unit test

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -127,7 +127,7 @@ type DataSources struct {
 
 	config *config.Config
 
-	// Some configuration variables read in
+	// Some configuration variables read in from the config
 	staleDuration time.Duration
 }
 
@@ -320,7 +320,7 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 
 	var prices []PegItem
 
-	// Eval all datasources on the same time. This time is on a per asset basis, but it is
+	// Eval all datasources from the reference time
 	for _, source := range sourceList {
 		var price PegItem
 		price, err = sources[source].FetchPegPrice(asset)
@@ -335,9 +335,7 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 			//	Is it stale AND the market is open? We can expect stale quotes in a closed market
 			if reference.Sub(price.When) > d.staleDuration && IsMarketOpen(asset, reference) {
 				// This price quote is stale, keep fetching prices
-				if IsMarketOpen(asset, reference) {
-					continue
-				}
+				continue
 			}
 
 			// This price is acceptable
@@ -350,6 +348,7 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 		return
 	}
 
+	// pa.When is uninitialized, so the reference.Sub(pa.When) == a very large value
 	mostRecent := reference.Sub(pa.When)
 	// Now we iterate over the prices we found, and return the most recent quote
 	for _, price := range prices {

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -338,8 +338,9 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 				continue
 			}
 
-			// This price is acceptable
-			break
+			// This price is acceptable, we can exit
+			pa = price
+			return pa, nil
 		}
 	}
 
@@ -348,13 +349,10 @@ func (d *DataSources) PullBestPrice(asset string, reference time.Time, sources m
 		return
 	}
 
-	// pa.When is uninitialized, so the reference.Sub(pa.When) == a very large value
-	mostRecent := reference.Sub(pa.When)
 	// Now we iterate over the prices we found, and return the most recent quote
 	for _, price := range prices {
-		since := reference.Sub(price.When)
-		if since < mostRecent {
-			mostRecent = since
+		// if the existing value is before the new price, the new price is more recent.
+		if pa.When.Before(price.When) {
 			pa = price
 		}
 	}

--- a/polling/assets_test.go
+++ b/polling/assets_test.go
@@ -231,3 +231,12 @@ func TestTruncate(t *testing.T) {
 		}
 	}
 }
+
+// Names should be consistent in the config and returned by the datasource
+func TestDataSourceNames(t *testing.T) {
+	for name, d := range AllDataSources {
+		if d.Name() != name {
+			t.Error("Name user types does not match name returned")
+		}
+	}
+}

--- a/polling/assets_test.go
+++ b/polling/assets_test.go
@@ -169,8 +169,8 @@ func TestDataSourceStaleness(t *testing.T) {
 		t.Error(err)
 	}
 
-	if price.Value != 1.0 {
-		t.Error("Expected a value of 1.0, as all are stale, but that is the most recent")
+	if price.Value != 20.0 {
+		t.Error("Expected a value of 20.0, as all are stale, but that is the highest priority")
 	}
 
 	// Make nothing stale

--- a/polling/assets_test.go
+++ b/polling/assets_test.go
@@ -20,7 +20,7 @@ func TestBasicPollingSources(t *testing.T) {
 	end := 6
 	// Create the unit test creator
 	NewTestingDataSource = func(config *config.Config, source string) (IDataSource, error) {
-		s := new(testutils.UnitTestDataSource)
+		s, _ := testutils.NewUnitTestDataSource(config)
 		v, err := strconv.Atoi(string(source[8]))
 		if err != nil {
 			panic(err)
@@ -50,7 +50,7 @@ func TestBasicPollingSources(t *testing.T) {
   UnitTest8=8
 `
 
-	c := config.NewConfig([]config.Provider{common.NewDefaultConfigOptionsProvider(), p})
+	c := config.NewConfig([]config.Provider{common.NewDefaultConfigOptionsProvider(), common.NewDefaultConfigOptionsProvider(), p})
 
 	s := NewDataSources(c)
 
@@ -101,7 +101,7 @@ func TestBasicPollingSources(t *testing.T) {
   # Specific coin overrides
   USD=UnitTest8
 `
-		c = config.NewConfig([]config.Provider{common.NewDefaultConfigOptionsProvider(), p})
+		c = config.NewConfig([]config.Provider{common.NewDefaultConfigOptionsProvider(), common.NewDefaultConfigOptionsProvider(), p})
 
 		s = NewDataSources(c)
 		pa, err := s.PullAllPEGAssets(1)

--- a/polling/coincap.go
+++ b/polling/coincap.go
@@ -48,8 +48,9 @@ func (d *CoinCapDataSource) FetchPegPrices() (peg PegAssets, err error) {
 
 	peg = make(map[string]PegItem)
 
-	var UnixTimestamp = resp.Timestamp
-	timestamp := time.Unix(resp.Timestamp, 0)
+	// Coincap resp is in milli seconds. Convert to unix
+	var UnixTimestamp = resp.Timestamp / 1000
+	timestamp := time.Unix(UnixTimestamp, 0)
 
 	for _, currency := range resp.Data {
 		switch currency.Symbol {
@@ -95,6 +96,10 @@ func (d *CoinCapDataSource) FetchPegPrice(peg string) (i PegItem, err error) {
 type CoinCapResponse struct {
 	Data      []CoinCapRecord `json:"data"`
 	Timestamp int64           `json:"timestamp"`
+}
+
+func (c CoinCapResponse) UnixTimestamp() int64 {
+	return c.Timestamp / 1000
 }
 
 type CoinCapRecord struct {

--- a/polling/fixedpeg.go
+++ b/polling/fixedpeg.go
@@ -1,0 +1,45 @@
+package polling
+
+import (
+	"time"
+
+	"github.com/zpatrick/go-config"
+)
+
+// FixedPEGDataSource is the datasource for PEG.
+// Currently PEG is valued at 0 USD. This will be removed when PEG
+// has value
+type FixedPEGDataSource struct {
+	config *config.Config
+}
+
+func NewFixedPEGDataSource(config *config.Config) (*FixedPEGDataSource, error) {
+	s := new(FixedPEGDataSource)
+	s.config = config
+
+	return s, nil
+}
+
+func (d *FixedPEGDataSource) Name() string {
+	return "FixedPEG"
+}
+
+func (d *FixedPEGDataSource) Url() string {
+	return "no-url"
+}
+
+func (d *FixedPEGDataSource) SupportedPegs() []string {
+	return []string{"PEG"}
+}
+
+func (d *FixedPEGDataSource) FetchPegPrices() (peg PegAssets, err error) {
+	peg = make(map[string]PegItem)
+	timestamp := time.Now()
+	// The USD price is always 0
+	peg["PEG"] = PegItem{Value: 0, WhenUnix: timestamp.Unix(), When: timestamp}
+	return
+}
+
+func (d *FixedPEGDataSource) FetchPegPrice(peg string) (i PegItem, err error) {
+	return FetchPegPrice(peg, d.FetchPegPrices)
+}

--- a/polling/fixedpeg_test.go
+++ b/polling/fixedpeg_test.go
@@ -2,6 +2,8 @@ package polling_test
 
 import (
 	"testing"
+
+	"github.com/pegnet/pegnet/polling"
 )
 
 func TestFixedPEGPeggedAssets(t *testing.T) {
@@ -10,4 +12,16 @@ func TestFixedPEGPeggedAssets(t *testing.T) {
 
 func TestActualFixedPEGPeggedAssets(t *testing.T) {
 	ActualDataSourceTest(t, "FixedPEG")
+}
+
+// Ensure price is fixed at 0
+func TestNewFixedPEGDataSource(t *testing.T) {
+	d, _ := polling.NewDataSource("FixedPEG", nil)
+	v, err := d.FetchPegPrice("PEG")
+	if err != nil {
+		t.Error(err)
+	}
+	if v.Value != 0 {
+		t.Error("Exp a 0 for the value of PEG")
+	}
 }

--- a/polling/fixedpeg_test.go
+++ b/polling/fixedpeg_test.go
@@ -1,0 +1,13 @@
+package polling_test
+
+import (
+	"testing"
+)
+
+func TestFixedPEGPeggedAssets(t *testing.T) {
+	FixedDataSourceTest(t, "FixedPEG", []byte{})
+}
+
+func TestActualFixedPEGPeggedAssets(t *testing.T) {
+	ActualDataSourceTest(t, "FixedPEG")
+}

--- a/polling/fixedusd.go
+++ b/polling/fixedusd.go
@@ -24,7 +24,7 @@ func (d *FixedUSDDataSource) Name() string {
 }
 
 func (d *FixedUSDDataSource) Url() string {
-	return "na"
+	return "no-url"
 }
 
 func (d *FixedUSDDataSource) SupportedPegs() []string {

--- a/polling/fixedusd_test.go
+++ b/polling/fixedusd_test.go
@@ -2,6 +2,8 @@ package polling_test
 
 import (
 	"testing"
+
+	"github.com/pegnet/pegnet/polling"
 )
 
 func TestFixedUSDPeggedAssets(t *testing.T) {
@@ -10,4 +12,16 @@ func TestFixedUSDPeggedAssets(t *testing.T) {
 
 func TestActualFixedUSDPeggedAssets(t *testing.T) {
 	ActualDataSourceTest(t, "FixedUSD")
+}
+
+// Ensure price is fixed at 1
+func TestNewFixedUSDDataSource(t *testing.T) {
+	d, _ := polling.NewDataSource("FixedUSD", nil)
+	v, err := d.FetchPegPrice("USD")
+	if err != nil {
+		t.Error(err)
+	}
+	if v.Value != 1 {
+		t.Error("Exp a 1 for the value of USD")
+	}
 }

--- a/polling/freeforex.go
+++ b/polling/freeforex.go
@@ -16,6 +16,8 @@ import (
 )
 
 // FreeForexAPIDataSource is the datasource at https://www.freeforexapi.com
+//	Notes:
+//		- Price quotes are every minute
 type FreeForexAPIDataSource struct {
 	config *config.Config
 }

--- a/polling/markets.go
+++ b/polling/markets.go
@@ -1,0 +1,67 @@
+package polling
+
+import (
+	"time"
+
+	"github.com/pegnet/pegnet/common"
+)
+
+// IsMarketOpen is used to determine is a stale quote is due to a closed market.
+// If the market is closed, we will allow stale quotes without having to fallback to
+// a backup datasource. This 'MarketOpen' does not have to be perfect, as if they market
+// is closed, but say it is open, then the polling will return the most recent quote it can find.
+// This is not bad behavior.
+func IsMarketOpen(asset string, reference time.Time) bool {
+	if common.AssetListContains(common.CurrencyAssets, asset) {
+		return ForexOpen(reference)
+	}
+	if common.AssetListContains(common.CommodityAssets, asset) {
+		return CommodityOpen(reference)
+	}
+	return true
+}
+
+// ForexOpen returns if the forex markets are open
+//	This is a rough estimate, which we use to allow stale quote data.
+// https://www.forex.com/en-us/support/trading-hours/
+// Opens:
+//		5:00 pm ET Sunday -> 21:00 UTC Sunday
+//	Closes:
+//		5:00 pm ET Friday -> 21:00 UTC Friday
+func ForexOpen(reference time.Time) bool {
+	utc := reference.UTC()
+	switch utc.Weekday() {
+	case time.Saturday:
+		return false
+	case time.Friday:
+		return reference.Hour() < 21
+	case time.Sunday:
+		return reference.Hour() >= 21
+	}
+	return true // Open Mon-Thurs for sure
+}
+
+// CommodityOpen returns if the commodity markets are open
+//	This is a rough estimate, which we use to allow stale quote data.
+//	There is a 1hr window where it is closed during the day, however I do
+// 	not see that on chain, and a fallback to the next datasource is not a bad
+//	result of letting the stale quote fallback.
+// https://www.forex.com/en-us/support/trading-hours/
+// Opens:
+//		6:00 pm ET Sunday -> 22:00 UTC Sunday
+//	Closes:
+//		5:00 pm ET Friday -> 21:00 UTC Friday
+func CommodityOpen(reference time.Time) bool {
+	utc := reference.UTC()
+	switch utc.Weekday() {
+	case time.Saturday:
+		return false
+	case time.Friday:
+		// Closes at 21:00
+		return reference.Hour() < 21
+	case time.Sunday:
+		// Opens at 22:00
+		return reference.Hour() >= 22
+	}
+	return true // Open Mon-Thurs for sure
+}

--- a/polling/markets_test.go
+++ b/polling/markets_test.go
@@ -1,0 +1,142 @@
+package polling_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pegnet/pegnet/polling"
+)
+
+func TestIsMarketOpen_Forex(t *testing.T) {
+	type IsOpenVec struct {
+		Reference time.Time
+		Exp       bool
+	}
+
+	vecs := []IsOpenVec{
+		// Monday
+		{Reference: silenceParse("16 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 12:04 UTC"), Exp: true},
+
+		// Tuesday
+		{Reference: silenceParse("17 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 12:04 UTC"), Exp: true},
+
+		// Wednesday
+		{Reference: silenceParse("18 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 12:04 UTC"), Exp: true},
+
+		// Thursday
+		{Reference: silenceParse("19 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 12:04 UTC"), Exp: true},
+
+		// Friday
+		{Reference: silenceParse("20 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 12:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 20:59 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 21:00 UTC"), Exp: false},
+		{Reference: silenceParse("20 Sep 19 23:04 UTC"), Exp: false},
+		{Reference: silenceParse("20 Sep 19 21:04 UTC"), Exp: false},
+
+		// Saturday
+		{Reference: silenceParse("21 Sep 19 15:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 00:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 12:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 23:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 21:04 UTC"), Exp: false},
+
+		// Sunday
+		{Reference: silenceParse("22 Sep 19 15:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 00:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 12:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 20:59 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 21:04 UTC"), Exp: true},
+	}
+
+	for _, vec := range vecs {
+		open := polling.IsMarketOpen("EUR", vec.Reference)
+		if open != vec.Exp {
+			t.Errorf("%s: exp %t,found %t", vec.Reference, vec.Exp, open)
+		}
+	}
+}
+
+func TestIsMarketOpen_Commodity(t *testing.T) {
+	type IsOpenVec struct {
+		Reference time.Time
+		Exp       bool
+	}
+
+	vecs := []IsOpenVec{
+		// Monday
+		{Reference: silenceParse("16 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 12:04 UTC"), Exp: true},
+
+		// Tuesday
+		{Reference: silenceParse("17 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 12:04 UTC"), Exp: true},
+
+		// Wednesday
+		{Reference: silenceParse("18 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 12:04 UTC"), Exp: true},
+
+		// Thursday
+		{Reference: silenceParse("19 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 12:04 UTC"), Exp: true},
+
+		// Friday
+		{Reference: silenceParse("20 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 12:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 20:59 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 21:00 UTC"), Exp: false},
+		{Reference: silenceParse("20 Sep 19 23:04 UTC"), Exp: false},
+		{Reference: silenceParse("20 Sep 19 21:04 UTC"), Exp: false},
+
+		// Saturday
+		{Reference: silenceParse("21 Sep 19 15:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 00:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 12:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 23:04 UTC"), Exp: false},
+		{Reference: silenceParse("21 Sep 19 21:04 UTC"), Exp: false},
+
+		// Sunday
+		{Reference: silenceParse("22 Sep 19 15:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 00:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 12:04 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 21:59 UTC"), Exp: false},
+		{Reference: silenceParse("22 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 22:04 UTC"), Exp: true},
+	}
+
+	for _, vec := range vecs {
+		open := polling.IsMarketOpen("XAG", vec.Reference)
+		if open != vec.Exp {
+			t.Errorf("%s: exp %t,found %t", vec.Reference, vec.Exp, open)
+		}
+	}
+}
+
+func silenceParse(s string) time.Time {
+	// 02 Jan 06 15:04 MST
+	t, _ := time.Parse(time.RFC822, s)
+	return t
+}

--- a/polling/markets_test.go
+++ b/polling/markets_test.go
@@ -135,6 +135,70 @@ func TestIsMarketOpen_Commodity(t *testing.T) {
 	}
 }
 
+func TestIsMarketOpen_Crypto(t *testing.T) {
+	type IsOpenVec struct {
+		Reference time.Time
+		Exp       bool
+	}
+
+	vecs := []IsOpenVec{
+		// Monday
+		{Reference: silenceParse("16 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("16 Sep 19 12:04 UTC"), Exp: true},
+
+		// Tuesday
+		{Reference: silenceParse("17 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("17 Sep 19 12:04 UTC"), Exp: true},
+
+		// Wednesday
+		{Reference: silenceParse("18 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("18 Sep 19 12:04 UTC"), Exp: true},
+
+		// Thursday
+		{Reference: silenceParse("19 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("19 Sep 19 12:04 UTC"), Exp: true},
+
+		// Friday
+		{Reference: silenceParse("20 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 12:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 20:59 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 21:00 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("20 Sep 19 21:04 UTC"), Exp: true},
+
+		// Saturday
+		{Reference: silenceParse("21 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("21 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("21 Sep 19 12:04 UTC"), Exp: true},
+		{Reference: silenceParse("21 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("21 Sep 19 21:04 UTC"), Exp: true},
+
+		// Sunday
+		{Reference: silenceParse("22 Sep 19 15:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 00:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 12:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 21:59 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 23:04 UTC"), Exp: true},
+		{Reference: silenceParse("22 Sep 19 22:04 UTC"), Exp: true},
+	}
+
+	for _, vec := range vecs {
+		open := polling.IsMarketOpen("XBT", vec.Reference)
+		if open != vec.Exp {
+			t.Errorf("%s: exp %t,found %t", vec.Reference, vec.Exp, open)
+		}
+	}
+}
+
 func silenceParse(s string) time.Time {
 	// 02 Jan 06 15:04 MST
 	t, _ := time.Parse(time.RFC822, s)

--- a/polling/openexchangerates_test.go
+++ b/polling/openexchangerates_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 )
 
+// Need an api key to run this
+//func TestActualOpenExchangeRatesPeggedAssets(t *testing.T) {
+//	ActualDataSourceTest(t, "OpenExchangeRates")
+//}
+
 // TestFixedOpenExchangeRatesPeggedAssets tests all the crypto assets are found on OpenExchangeRates from fixed
 func TestFixedOpenExchangeRatesPeggedAssets(t *testing.T) {
 	FixedDataSourceTest(t, "OpenExchangeRates", []byte(openExchangeRateResponse))

--- a/testutils/polling.go
+++ b/testutils/polling.go
@@ -42,10 +42,14 @@ type UnitTestDataSource struct {
 	Value      float64
 	Assets     []string
 	SourceName string
+
+	// How to timestamp price quotes
+	Timestamp func() time.Time
 }
 
 func NewUnitTestDataSource(config *config.Config) (*UnitTestDataSource, error) {
 	s := new(UnitTestDataSource)
+	s.Timestamp = time.Now
 	return s, nil
 }
 
@@ -64,7 +68,7 @@ func (d *UnitTestDataSource) SupportedPegs() []string {
 func (d *UnitTestDataSource) FetchPegPrices() (peg polling.PegAssets, err error) {
 	peg = make(map[string]polling.PegItem)
 
-	timestamp := time.Now()
+	timestamp := d.Timestamp()
 	for _, asset := range d.SupportedPegs() {
 		peg[asset] = polling.PegItem{Value: d.Value, When: timestamp, WhenUnix: timestamp.Unix()}
 	}

--- a/testutils/polling.go
+++ b/testutils/polling.go
@@ -15,7 +15,7 @@ import (
 // AlwaysOnePolling returns 1 for all prices
 func AlwaysOnePolling() *polling.DataSources {
 	polling.NewTestingDataSource = func(config *config.Config, source string) (polling.IDataSource, error) {
-		s := new(UnitTestDataSource)
+		s, _ := NewUnitTestDataSource(config)
 		v, err := strconv.Atoi(string(source[8]))
 		if err != nil {
 			panic(err)
@@ -32,7 +32,7 @@ func AlwaysOnePolling() *polling.DataSources {
 [OracleDataSources]
   UnitTest1=1
 `
-	c := config.NewConfig([]config.Provider{p})
+	c := config.NewConfig([]config.Provider{common.NewDefaultConfigOptionsProvider(), p})
 	s := polling.NewDataSources(c)
 	return s
 }


### PR DESCRIPTION
This makes stale polling results fallback to the next data source. Once we find a datasource that is not stale (or we run out), we take the most recent quote out of our data sources. This would allow us to re-enable crypto on 1 forge, as that error they had awhile back was a stale price quote. 

So questions for reviewers before I make this a not-draft pr:

- Should I re-enable crypto on 1 forge in this PR?
- ~~Should we explicitly handle weekends for forex? (I think this is a must, just want to talk about how)~~
  - I ended up programming in the Open/Close market times for Forex and Commodities. Holidays and such will count as "open" and all data sources will be queried. So that means if you have 4 sources for forex, all 4 will be queried when the market is closed on an unusual time. Do you think we will need a syntax for "only fallback during a price error, not a stale error"?
- Is 30 min a good "stale" duration?