### PR TITLE
Detailed logs

### DIFF
--- a/mining/stats.go
+++ b/mining/stats.go
@@ -197,12 +197,25 @@ func (g *GroupMinerStats) AvgHashRatePerMiner() float64 {
 	return acc / totalDur.Seconds()
 }
 
+// AvgDurationPerMiner is the average duration of mining across all miners.
+func (g *GroupMinerStats) AvgDurationPerMiner() time.Duration {
+	var totalDur time.Duration
+	// Weight by duration
+	for _, m := range g.Miners {
+		elapsed := m.Stop.Sub(m.Start)
+		totalDur += elapsed
+	}
+
+	return totalDur / time.Duration(len(g.Miners))
+}
+
 func (g *GroupMinerStats) LogFields() log.Fields {
 	f := log.Fields{
 		"dbht":           g.BlockHeight,
 		"miners":         len(g.Miners),
 		"miner_hashrate": fmt.Sprintf("%s/s", humanize.FormatFloat("", g.AvgHashRatePerMiner())),
 		"total_hashrate": fmt.Sprintf("%s/s", humanize.FormatFloat("", g.TotalHashPower())),
+		"avg_duration":   fmt.Sprintf("%s", g.AvgDurationPerMiner()),
 	}
 
 	for k, v := range g.Tags {

--- a/networkMiner/server.go
+++ b/networkMiner/server.go
@@ -351,7 +351,7 @@ func (s *MiningServer) onClientConnectionClosed(c *TCPClient, err error) {
 
 	delete(s.clients, c.id)
 	s.numClients = len(s.clients)
-	log.WithFields(s.Fields()).Info("Client disconnected")
+	log.WithFields(s.Fields()).WithFields(c.LogFields()).Info("Client disconnected")
 }
 
 func (s *MiningServer) onNewClient(c *TCPClient) {
@@ -362,7 +362,7 @@ func (s *MiningServer) onNewClient(c *TCPClient) {
 			log.WithFields(s.Fields()).WithError(err).WithField("func", "onNewClient").Error("failed to send challenge")
 			return
 		}
-		log.WithFields(s.Fields()).WithField("id", c.id).Info("Client pending challenge")
+		log.WithFields(s.Fields()).WithFields(c.LogFields()).Info("Client pending challenge")
 	} else {
 		err := c.SendNetworkCommand(NewNetworkMessage(Ping, nil))
 		if err != nil {
@@ -381,7 +381,7 @@ func (s *MiningServer) Accept(c *TCPClient) {
 
 	s.clients[c.id] = c
 	s.numClients = len(s.clients)
-	log.WithFields(s.Fields()).WithField("id", c.id).Info("Client connected")
+	log.WithFields(s.Fields()).WithFields(c.LogFields()).Info("Client connected")
 }
 
 func (s *MiningServer) WriteEntry(entry *factom.Entry) error {

--- a/networkMiner/tcpServer.go
+++ b/networkMiner/tcpServer.go
@@ -51,6 +51,18 @@ func NewTCPClient(conn net.Conn, s *TCPServer) *TCPClient {
 	return m
 }
 
+func (c *TCPClient) LogFields() log.Fields {
+	ip := "unknown"
+	if c.conn != nil { // Protect against an nil dereference
+		ip = c.conn.RemoteAddr().String()
+	}
+
+	return log.Fields{
+		"ip": ip,
+		"id": c.id,
+	}
+}
+
 func (c *TCPClient) init() {
 	c.decoder = gob.NewDecoder(c.conn)
 	c.encoder = gob.NewEncoder(c.conn)


### PR DESCRIPTION
Adding some more detailed logs:

- Adds `avg_duration=30.645401867s ` (I had custom net with 40s blocks) to miner stats output. When people see varying hash rates, this could signal fast/slow minutes on factomd.
- Added the client's ip to more log statements from the coordinator.