### PR TITLE
Changed the decode entry to use the right extid for version

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -600,7 +600,7 @@ var decodeEntry = &cobra.Command{
 			CmdError(cmd, fmt.Errorf("not an opr entry"))
 		}
 
-		if len(entry.ExtIDs[0]) != 1 {
+		if len(entry.ExtIDs[2]) != 1 {
 			CmdError(cmd, fmt.Errorf("opr version must be 1 byte in length, found %d", len(entry.ExtIDs[0])))
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,7 @@ func init() {
 	RootCmd.PersistentFlags().Int("profileport", 7060, "Change profiling port (default 16060)")
 	RootCmd.PersistentFlags().String("network", "", "The pegnet network to target. <MainNet|TestNet>")
 
-	RootCmd.PersistentFlags().StringArrayP("override", "o", []string{}, "Custom config overrides. Can override any setting")
+	RootCmd.PersistentFlags().StringArrayP("override", "r", []string{}, "Custom config overrides. Can override any setting")
 
 	// Initialize the config file with the config, then with cmd flags
 	RootCmd.PersistentPreRunE = rootPreRunSetup


### PR DESCRIPTION
Also changed a shorthand flag, as 'o' is used elsewhere