### PR TITLE
OPR Min diff was based on the full opr set sorted by self reported difficulty

### DIFF
--- a/opr/grader.go
+++ b/opr/grader.go
@@ -188,10 +188,11 @@ func (g *QuickGrader) Run(monitor *common.Monitor, ctx context.Context) {
 			if oprs != nil && len(oprs.GradedOPRs) > 0 {
 				// top 10 get paid for v1, top 25 for v2
 				amt := g.MinRecords(int64(oprs.GradedOPRs[0].Dbht))
+				// TODO: We should really only send the Graded, rather than graded and ToBePaid
 				if len(oprs.GradedOPRs) >= amt {
 					winners.ToBePaid = oprs.GradedOPRs[:amt]
 				}
-				winners.AllOPRs = oprs.OPRs
+				winners.GradedOPRs = oprs.GradedOPRs
 			}
 
 			// Alert followers that we have graded the previous block
@@ -634,8 +635,8 @@ func (g *QuickGrader) OprByShortHash(shorthash string) OraclePriceRecord {
 
 // OPRs is the message sent by the Grader
 type OPRs struct {
-	ToBePaid []*OraclePriceRecord
-	AllOPRs  []*OraclePriceRecord
+	ToBePaid   []*OraclePriceRecord
+	GradedOPRs []*OraclePriceRecord
 
 	// Since this is used as a message, we need a way to send an error
 	Error error

--- a/opr/recorder.go
+++ b/opr/recorder.go
@@ -125,25 +125,27 @@ func (c *ChainRecorder) WriteMinerCSV() error {
 	for i, block := range g.GetBlocks() {
 		var _ = i
 		last := 50
-		if len(block.OPRs) < 50 {
-			last = len(block.OPRs) - 1
+		if len(block.GradedOPRs) < 50 {
+			last = len(block.GradedOPRs) - 1
 		}
 		if last < 0 {
 			continue
 		}
 
-		cutoffD := CalculateMinimumDifficultyFromOPRs(block.OPRs, cutoff)
+		// Sort the graded by difficulty
+		sort.SliceStable(block.GradedOPRs, func(i, j int) bool { return block.GradedOPRs[i].Difficulty > block.GradedOPRs[j].Difficulty })
+		cutoffD := CalculateMinimumDifficultyFromOPRs(block.GradedOPRs, cutoff)
 
 		err = writer.Write([]string{
 			fmt.Sprintf("%d", block.Dbht),
 			fmt.Sprintf("%d", len(block.OPRs)),
 
-			fmt.Sprintf("%d", block.OPRs[0].Difficulty),
-			fmt.Sprintf("%x", block.OPRs[0].Difficulty),
+			fmt.Sprintf("%d", block.GradedOPRs[0].Difficulty),
+			fmt.Sprintf("%x", block.GradedOPRs[0].Difficulty),
 
 			fmt.Sprintf("%d", last),
-			fmt.Sprintf("%d", block.OPRs[last].Difficulty),
-			fmt.Sprintf("%x", block.OPRs[last].Difficulty),
+			fmt.Sprintf("%d", block.GradedOPRs[last].Difficulty),
+			fmt.Sprintf("%x", block.GradedOPRs[last].Difficulty),
 
 			fmt.Sprintf("%d", cutoff),
 			fmt.Sprintf("%d", cutoffD),


### PR DESCRIPTION
This is problematic if there are invalid oprs in the top 50 by
self reported. It ws putting incorrect oprs on the boundary that decides
the cutoff difficulty. Switch to using the graded set, and sorting it by
difficulty

I ran some tests to verify this was the issue, and got the same mindiff that my miner was using in the tests. It also found the other blocks with spikes.