### PR TITLE
(conversion module) integer overflow

### DIFF
--- a/modules/conversions/conversions.go
+++ b/modules/conversions/conversions.go
@@ -2,8 +2,11 @@ package conversions
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 )
+
+var max *big.Int = big.NewInt(math.MaxInt64)
 
 // Convert takes an input amount and returns an output amount that can be created
 // from it, given the two rates `fromRate` and `toRate` denominated in 1e-8 USD.
@@ -37,5 +40,8 @@ func Convert(amount int64, fromRate, toRate uint64) (int64, error) {
 	//  (amt * fromrate) / torate
 	num := big.NewInt(0).Mul(amt, fr)
 	num = num.Div(num, tr)
+	if max.Cmp(num) < 0 { // max < num
+		return 0, fmt.Errorf("integer overflow")
+	}
 	return num.Int64(), nil
 }

--- a/modules/conversions/conversions_test.go
+++ b/modules/conversions/conversions_test.go
@@ -42,6 +42,7 @@ var conversionTestVectors = []string{
 	`{"name": "whole unit input", "x_rate": 1000000000000, "y_rate": 100000000, "x1": 100000000, "y1": 1000000000000, "x2": 100000000, "y2": 1000000000000}`,
 	`{"name": "smallest unit input", "x_rate": 1000000000000, "y_rate": 100000000, "x1": 1, "y1": 10000, "x2": 1, "y2": 10000}`,
 	`{"name": "smallest unit input (truncated result)", "x_rate": 100000000, "y_rate": 1000000000000, "x1": 1, "y1": 0, "x2": 0, "y2": 0}`,
+	`{"name": "int64 overflow", "error_string": "integer overflow", "x_rate": 9223372036854775807, "y_rate": 1, "x1": 2, "y1": 0}`,
 }
 
 func TestConversions_Convert_Vectors(t *testing.T) {


### PR DESCRIPTION
Noticed that at the moment, integer overflows would result in an "undefined value", so I added a check that ensures the result actually fits inside of an int64