### PR TITLE
Added code to log SPR entry hashes

### DIFF
--- a/staking/entryWriter.go
+++ b/staking/entryWriter.go
@@ -121,12 +121,12 @@ func (w *EntryWriter) writeStakingRecord() error {
 		return fmt.Errorf("no spr template")
 	}
 
-	fctAddresses, err := w.config.String("Staker.CoinbaseAddress")
+	fctCommaList, err := w.config.String("Staker.CoinbaseAddress")
 	if err != nil { // Not likely to happen since we
 		return errors.New("No fctAddress found") // check for bad addresses earlier
 	}
-	fctAddrs := strings.Split(fctAddresses, ",")
-	for _, addr := range fctAddrs {
+	fctSlice := strings.Split(fctCommaList, ",")
+	for _, addr := range fctSlice {
 		operation := func() error {
 			var err1, err2 error
 
@@ -158,6 +158,17 @@ func (w *EntryWriter) writeStakingRecord() error {
 		if err != nil {
 			return err
 		}
+	}
+	ecAdr, _ := w.config.String("Staker.ECAddress")
+	bal, err := factom.GetECBalance(ecAdr)
+	if err == nil { // we wont worry about this failing since we have tested it many times before now.
+		days := float64(bal) / 144 / float64(len(fctSlice))
+		log.WithFields(log.Fields{
+			"ECAddress":      ecAdr,
+			"Balance":        bal,
+			"NumberOfStakes": len(fctSlice),
+			"DaysLeft":       days,
+		}).Info("ECAddress Status")
 	}
 	return nil
 }

--- a/staking/staker.go
+++ b/staking/staker.go
@@ -104,12 +104,11 @@ func CheckStakingAddresses(config *config.Config) {
 		panic("EC Balance is zero for " + ecAddress)
 	}
 
-	days := float64(bal) / 144
-	eqs := "==============================================================\n"
+	days := float64(bal) / 144 / float64(len(fctSlice))
+	eqs := "=============================================================================\n"
 	io.WriteString(os.Stderr, fmt.Sprintf("\n%s", eqs))
-	io.WriteString(os.Stderr, fmt.Sprintf("%s\n", ecAddress))
-	io.WriteString(os.Stderr, fmt.Sprintf("ECBalance is %d\n", bal))
-	io.WriteString(os.Stderr, fmt.Sprintf("Staking can run with this balance for ~%7.3f days\n", days))
+	io.WriteString(os.Stderr, fmt.Sprintf("   %s balance is %d\n", ecAddress, bal))
+	io.WriteString(os.Stderr, fmt.Sprintf("   Staking %d addresses can be supported for ~%7.3f days\n", len(fctSlice), days))
 	io.WriteString(os.Stderr, fmt.Sprintf("%s\n", eqs))
 }
 


### PR DESCRIPTION
This is necessary to allow anyone to compare what they are staking to what is going into chains.

A later pull request will collect the entry hashes and check them in the next minute and report on spr recording failures.  That's a bit more tricky the way the code is organized.