### PR TITLE
WIP - SPR signatures

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,6 +173,7 @@ func rootPreRunSetup(cmd *cobra.Command, args []string) error {
 		common.FloatingPegPriceActivation = 0
 		common.V4HeightActivation = 0
 		common.V20HeightActivation = 0
+		common.SprSignatureActivation = 5
 	}
 
 	if testingact, _ := cmd.Flags().GetInt32("testingact"); testingact != -1 {

--- a/common/activation.go
+++ b/common/activation.go
@@ -48,7 +48,10 @@ var (
 			return 6 // Latest code version
 		},
 		TestNetwork: func(height int64) uint8 {
-			return 5
+			if height < SprSignatureActivation {
+				return 5
+			}
+			return 6 // Latest code version
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -21,10 +21,11 @@ require (
 	github.com/FactomProject/go-simplejson v0.5.0 // indirect
 	github.com/FactomProject/go-spew v0.0.0-20160301052117-ddfaec9b42f5 // indirect
 	github.com/FactomProject/gocoding v0.0.0-20150814232539-59666ce39524 // indirect
-	github.com/FactomProject/goleveldb v0.2.1 // indirect
+	github.com/FactomProject/goleveldb v0.2.2-0.20170418171130-e7800c6976c5 // indirect
 	github.com/FactomProject/logrustash v0.0.0-20171005151533-9c7278ede46e // indirect
 	github.com/FactomProject/netki-go-partner-client v0.0.0-20160324224126-426acb535e66 // indirect
 	github.com/FactomProject/serveridentity v0.0.0-20180611231115-cf42d2aa8deb // indirect
+	github.com/FactomProject/snappy-go v0.0.0-20170202213131-f2f83b22c29e // indirect
 	github.com/FactomProject/web v0.1.0 // indirect
 	github.com/alexandrevicenzi/go-sse v0.0.0-20190531224209-805eefa457e7
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
@@ -61,5 +62,4 @@ require (
 	gopkg.in/gcfg.v1 v1.2.3 // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=

--- a/modules/graderStake/base.go
+++ b/modules/graderStake/base.go
@@ -18,7 +18,7 @@ func NewGrader(version uint8, height int32) (BlockGrader, error) {
 		return nil, fmt.Errorf("height must be > 0")
 	}
 	switch version {
-	case 5:
+	case 5, 6:
 		s1 := new(S1BlockGrader)
 		s1.height = height
 		return s1, nil

--- a/modules/graderStake/s1_util.go
+++ b/modules/graderStake/s1_util.go
@@ -22,7 +22,6 @@ func S1Payout(index int) int64 {
 
 // ValidateS1 validates the provided data using the specified parameters
 func ValidateS1(entryhash []byte, extids [][]byte, height int32, content []byte) (*GradingSPR, error) {
-	fmt.Println("In ValidateS1")
 	if len(entryhash) != 32 {
 		return nil, NewValidateError("invalid entry hash length")
 	}
@@ -45,12 +44,15 @@ func ValidateS1(entryhash []byte, extids [][]byte, height int32, content []byte)
 
 	if extids[0][0] == 6 {
 		fmt.Println("Verifying signature")
-		err := primitives.VerifySignature(content, []byte(o.Address), extids[2])
-		if err != nil {
+		fmt.Printf("RCD: %v \n", extids[1])
+		fmt.Printf("Signature: %v \n", extids[2])
+		fmt.Printf("Content: %v \n", content)
+		err2 := primitives.VerifySignature(content, extids[1], extids[2])
+		if err2 != nil {
+			fmt.Printf("%v \n", err2)
 			return nil, NewValidateError("invalid signature")
 		}
-	} else {
-		fmt.Printf("Not verifying signature: %s ", extids[0][0])
+		fmt.Println("Signature valid")
 	}
 
 	if o.Height != height {

--- a/polling/assets.go
+++ b/polling/assets.go
@@ -275,7 +275,7 @@ func (d *DataSources) PullAllPEGAssets(oprversion uint8) (pa PegAssets, err erro
 	if oprversion == 4 {
 		assets = common.AssetsV4
 	}
-	if oprversion == 5 {
+	if oprversion == 5 || oprversion == 6 {
 		assets = common.AssetsV5
 	}
 	start := time.Now()

--- a/spr/assetList.go
+++ b/spr/assetList.go
@@ -55,7 +55,7 @@ func (o StakingPriceRecordAssetList) Value(asset string) float64 {
 // List returns the list of assets in the global order
 func (o StakingPriceRecordAssetList) List(version uint8) []Token {
 	assets := common.AssetsV5
-	if version == 5 {
+	if version == 5 || version == 6 {
 		assets = common.AssetsV5
 	}
 	tokens := make([]Token, len(assets))
@@ -101,7 +101,7 @@ func (o StakingPriceRecordAssetList) MarshalJSON() ([]byte, error) {
 		assets = common.AssetsV2
 	case 4:
 		assets = common.AssetsV4
-	case 5:
+	case 5, 6:
 		assets = common.AssetsV5
 	}
 


### PR DESCRIPTION
I'll leave the debugging output in there.  You can see that the RCD, Signature, and Content are the exact same coming from pegnet, and then read by pegnetd, but primitives.VerifySignature() still says the signature is invalid.  The only thing I can figure is that I'm not passing the values into VerifySignature() the way that it wants to receive them.... I don't know.
It's worth noting that there were quite a few places we had to make changes because of the new SprVersion... also, in at least one place, PullAllPEGAssets(), the spr.Version is passed in to a function expecting an oprversion.  As these versions diverge, we're going to run into problems.
To do the signing we went back to my original plan of using factom.SignData(spr.CoinbaseAddress, e.Content).  Paul was able to extract just that function into a branch of the existing factom library we were already using, so we didn't end up having to refactor everything.  The benefit of doing this is that a private key never has to go over the wire.  It also means that stakers must import their private key into the wallet to stake.
I'm going to push my WIP up to my fork of pegnet and the submit a PR into the Feature_spr_signatures branch in pegnet.  I'll do the same with pegnetd , which is really just a dependency update on the pegnet change.
Oh... in root.go, we set the common.SprSignatureActivation to 5 when using the --testing flag so there are both signed and not signed SPRs to make sure we can handle both