### PR TITLE
[Feature] Set pnmc as default data source in configuration

### DIFF
--- a/config/defaultconfig.ini
+++ b/config/defaultconfig.ini
@@ -162,14 +162,14 @@
   # Free sources, signup required
   CoinMarketCap=-1
   #   Hourly data for the commodities
-  OpenExchangeRates=9
+  OpenExchangeRates=-1
 
   # ----------------
   #  Free sources, no signup required
-  FreeForexAPI=3
-  AlternativeMe=2
+  FreeForexAPI=-1
+  AlternativeMe=-1
   CoinCap=-1
-  PegnetMarketcap=-1
+  PegnetMarketcap=1
   CoinGecko=-1
 
   #   Web scraping, rank it low

--- a/config/defaultconfig.ini
+++ b/config/defaultconfig.ini
@@ -162,12 +162,12 @@
   # Free sources, signup required
   CoinMarketCap=-1
   #   Hourly data for the commodities
-  OpenExchangeRates=-1
+  OpenExchangeRates=9
 
   # ----------------
   #  Free sources, no signup required
-  FreeForexAPI=-1
-  AlternativeMe=-1
+  FreeForexAPI=3
+  AlternativeMe=2
   CoinCap=-1
   PegnetMarketcap=1
   CoinGecko=-1


### PR DESCRIPTION
Set PegNetMarketCap APIs as default data source in configuration